### PR TITLE
Add AutoOrganizer core implementation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/auto_organizer/__init__.py
+++ b/auto_organizer/__init__.py
@@ -1,0 +1,11 @@
+"""AutoOrganizer package implementing the design specification."""
+
+from .organizer import AutoOrganizer
+from .config import OrganizeOptions, OrganizeTask, OrganizeResult
+
+__all__ = [
+    "AutoOrganizer",
+    "OrganizeOptions",
+    "OrganizeTask",
+    "OrganizeResult",
+]

--- a/auto_organizer/classifier.py
+++ b/auto_organizer/classifier.py
@@ -1,0 +1,165 @@
+"""File classification rules and engine."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, Tuple
+
+from .config import FileInfo
+
+
+@dataclass
+class CategoryRule:
+    id: str
+    name: str
+    emoji: str
+    extensions: Tuple[str, ...] = ()
+    keywords: Tuple[str, ...] = ()
+    mime_types: Tuple[str, ...] = ()
+    min_size: int | None = None
+    priority: int = 0
+
+
+class ClassificationEngine:
+    """Multi-layer rule-based file classifier."""
+
+    DEFAULT_RULES: Tuple[CategoryRule, ...] = (
+        CategoryRule(
+            id="documents",
+            name="📄 文件",
+            emoji="📄",
+            extensions=(".doc", ".docx", ".txt", ".rtf", ".pages", ".md"),
+            keywords=("文件", "document", "報告", "report"),
+            mime_types=("application/msword", "text/plain"),
+            priority=10,
+        ),
+        CategoryRule(
+            id="images",
+            name="🖼️ 圖片",
+            emoji="🖼️",
+            extensions=(".jpg", ".jpeg", ".png", ".gif", ".heic", ".svg"),
+            keywords=("screenshot", "截圖", "photo", "照片"),
+            mime_types=("image/jpeg", "image/png", "image/gif"),
+            priority=10,
+        ),
+        CategoryRule(
+            id="code",
+            name="💻 程式碼",
+            emoji="💻",
+            extensions=(".html", ".css", ".js", ".py", ".java", ".cpp", ".swift"),
+            keywords=("source", "src", "code"),
+            mime_types=("text/html", "application/javascript"),
+            priority=10,
+        ),
+        CategoryRule(
+            id="archives",
+            name="📁 壓縮檔",
+            emoji="📁",
+            extensions=(".zip", ".rar", ".7z", ".tar", ".gz", ".dmg"),
+            keywords=("backup", "備份", "archive", "download", "下載"),
+            min_size=104_857_600,
+            priority=8,
+        ),
+        CategoryRule(
+            id="audio",
+            name="🎵 音樂",
+            emoji="🎵",
+            extensions=(".mp3", ".m4a", ".wav", ".flac"),
+            priority=10,
+        ),
+        CategoryRule(
+            id="video",
+            name="🎬 影片",
+            emoji="🎬",
+            extensions=(".mp4", ".mov", ".avi", ".mkv"),
+            priority=10,
+        ),
+        CategoryRule(
+            id="design",
+            name="🎨 設計",
+            emoji="🎨",
+            extensions=(".psd", ".ai", ".sketch", ".figma"),
+            priority=10,
+        ),
+        CategoryRule(
+            id="spreadsheets",
+            name="📊 試算表",
+            emoji="📊",
+            extensions=(".xlsx", ".xls", ".csv", ".numbers"),
+            priority=10,
+        ),
+        CategoryRule(
+            id="ebooks",
+            name="📚 電子書",
+            emoji="📚",
+            extensions=(".epub", ".mobi", ".azw"),
+            keywords=("book", "書", "manual", "手冊"),
+            priority=10,
+        ),
+        CategoryRule(
+            id="data",
+            name="🗄️ 數據",
+            emoji="🗄️",
+            extensions=(".json", ".xml", ".sql"),
+            priority=10,
+        ),
+        CategoryRule(
+            id="apps",
+            name="📦 應用程式",
+            emoji="📦",
+            extensions=(".pkg", ".app", ".exe"),
+            priority=10,
+        ),
+    )
+
+    DEFAULT_CATEGORY = CategoryRule(
+        id="others", name="🗂️ 其他", emoji="🗂️", priority=0
+    )
+
+    def __init__(self) -> None:
+        self.rules: Dict[str, CategoryRule] = {rule.id: rule for rule in self.DEFAULT_RULES}
+
+    def classify(self, file_info: FileInfo) -> tuple[str, float]:
+        scores: Dict[str, int] = {}
+
+        for rule in self.rules.values():
+            score = self._score_rule(rule, file_info)
+            if score:
+                scores[rule.id] = scores.get(rule.id, 0) + score
+
+        if not scores:
+            return self.DEFAULT_CATEGORY.name, 0.0
+
+        best_id = max(scores, key=scores.get)
+        best_rule = self.rules[best_id]
+        return best_rule.name, float(scores[best_id])
+
+    def load_custom_rules(self, path: Path) -> None:
+        data = json.loads(path.read_text(encoding="utf-8"))
+        categories = data.get("classificationRules", {}).get("categories", [])
+        for category in categories:
+            rules = category.get("rules", {})
+            rule = CategoryRule(
+                id=category["id"],
+                name=category.get("name", category["id"]),
+                emoji=category.get("emoji", ""),
+                extensions=tuple(ext.lower() for ext in rules.get("extensions", [])),
+                keywords=tuple(rules.get("keywords", [])),
+                mime_types=tuple(rules.get("mimeTypes", [])),
+                min_size=rules.get("minSize"),
+                priority=rules.get("priority", 0),
+            )
+            self.rules[rule.id] = rule
+
+    @staticmethod
+    def _score_rule(rule: CategoryRule, file_info: FileInfo) -> int:
+        score = 0
+        if rule.extensions and file_info.file_extension in rule.extensions:
+            score += rule.priority
+        if rule.keywords and any(keyword in file_info.file_name for keyword in rule.keywords):
+            score += rule.priority + 5
+        if rule.min_size and file_info.file_size >= rule.min_size:
+            score += max(5, rule.priority // 2)
+        return score

--- a/auto_organizer/cli.py
+++ b/auto_organizer/cli.py
@@ -1,0 +1,56 @@
+"""Command line interface for AutoOrganizer."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+from .organizer import AutoOrganizer, OrganizeOptions
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="AutoOrganizer CLI")
+    parser.add_argument("sources", nargs="+", help="Source folders to organize")
+    parser.add_argument("--target", required=True, help="Target folder for organized files")
+    parser.add_argument("--no-recursive", action="store_true", help="Disable recursive scanning")
+    parser.add_argument("--skip-duplicates", action="store_true", help="Skip duplicates instead of renaming")
+    parser.add_argument("--overwrite", action="store_true", help="Overwrite duplicates")
+    parser.add_argument("--rules", type=str, help="Path to custom classification rules JSON")
+    parser.add_argument("--no-report", action="store_true", help="Do not generate report")
+    return parser.parse_args()
+
+
+def build_options(args: argparse.Namespace) -> OrganizeOptions:
+    from .config import DuplicateStrategy
+
+    strategy = DuplicateStrategy.RENAME
+    if args.skip_duplicates:
+        strategy = DuplicateStrategy.SKIP
+    elif args.overwrite:
+        strategy = DuplicateStrategy.OVERWRITE
+
+    return OrganizeOptions(
+        recursive=not args.no_recursive,
+        handle_duplicates=strategy != DuplicateStrategy.SKIP,
+        duplicate_strategy=strategy,
+        generate_report=not args.no_report,
+    )
+
+
+def main() -> None:
+    args = parse_args()
+    options = build_options(args)
+    organizer = AutoOrganizer(options)
+    if args.rules:
+        organizer.load_custom_rules(Path(args.rules))
+    result = organizer.organize([Path(src) for src in args.sources], Path(args.target))
+    if result.success:
+        print(f"Processed {result.processed_files} files, {result.duplicates} duplicates handled.")
+    else:
+        print("Organization completed with errors:")
+        for error in result.errors:
+            print(f" - {error}")
+
+
+if __name__ == "__main__":
+    main()

--- a/auto_organizer/config.py
+++ b/auto_organizer/config.py
@@ -1,0 +1,88 @@
+"""Configuration and data structures for AutoOrganizer."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime
+from enum import Enum
+from pathlib import Path
+from typing import Dict, Iterable, List, Optional
+
+
+class DuplicateStrategy(str, Enum):
+    """Supported strategies for handling duplicate files."""
+
+    RENAME = "rename"
+    SKIP = "skip"
+    OVERWRITE = "overwrite"
+
+
+@dataclass
+class OrganizeOptions:
+    """Options that control how the organizer behaves."""
+
+    recursive: bool = True
+    handle_duplicates: bool = True
+    duplicate_strategy: DuplicateStrategy = DuplicateStrategy.RENAME
+    generate_report: bool = True
+    silent_mode: bool = False
+    whitelist_patterns: Iterable[str] = field(
+        default_factory=lambda: ("重要資料", "專案檔案", "工作文件")
+    )
+
+
+@dataclass
+class Statistics:
+    """Statistics collected during an organization run."""
+
+    total_files: int = 0
+    processed_files: int = 0
+    total_folders: int = 0
+    processed_folders: int = 0
+    skipped_items: int = 0
+    errors: int = 0
+    duplicates: int = 0
+
+
+@dataclass
+class FileInfo:
+    """Detailed metadata about a file encountered during scanning."""
+
+    file_path: Path
+    file_name: str
+    file_extension: str
+    file_size: int
+    creation_date: Optional[datetime]
+    modification_date: Optional[datetime]
+    source_folder: Path
+    is_system_file: bool = False
+    category: Optional[str] = None
+    confidence: float = 0.0
+    process_status: str = "pending"
+    error_message: Optional[str] = None
+
+
+@dataclass
+class OrganizeTask:
+    """Task definition describing a run of the organizer."""
+
+    task_id: str
+    execution_time: datetime
+    source_folders: List[Path]
+    target_folder: Path
+    mode: str = "ultimate"
+    naming_rule: str = "original"
+    options: OrganizeOptions = field(default_factory=OrganizeOptions)
+    statistics: Statistics = field(default_factory=Statistics)
+
+
+@dataclass
+class OrganizeResult:
+    """Summary produced once the organizer finishes running."""
+
+    success: bool
+    processed_files: int
+    skipped_files: int
+    duplicates: int
+    errors: List[str] = field(default_factory=list)
+    details: Dict[str, List[Path]] = field(default_factory=dict)

--- a/auto_organizer/filters.py
+++ b/auto_organizer/filters.py
@@ -1,0 +1,68 @@
+"""System file filtering logic."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable, List, Tuple
+
+
+@dataclass
+class FilterRule:
+    pattern: str
+    rule_type: str
+    action: str
+    reason: str
+    threshold: int | None = None
+
+
+class SystemFileFilter:
+    """Determine whether a file should be skipped based on rules."""
+
+    DEFAULT_RULES: Tuple[FilterRule, ...] = (
+        FilterRule("OneDrive", "contains", "skip", "OneDrive 同步檔案"),
+        FilterRule("iCloud", "contains", "skip", "iCloud 同步檔案"),
+        FilterRule("Dropbox", "contains", "skip", "Dropbox 同步檔案"),
+        FilterRule("Google Drive", "contains", "skip", "Google Drive 檔案"),
+        FilterRule(".", "startsWith", "skip", "隱藏檔案"),
+        FilterRule(".DS_Store", "equals", "skip", "macOS 系統檔案"),
+        FilterRule("Thumbs.db", "equals", "skip", "Windows 快取檔案"),
+        FilterRule(".git", "contains", "skip", "Git 版本控制"),
+        FilterRule("node_modules", "contains", "skip", "Node.js 依賴"),
+        FilterRule("__pycache__", "contains", "skip", "Python 快取"),
+        FilterRule(".vscode", "contains", "skip", "VSCode 設定"),
+        FilterRule("", "length", "skip", "檔名過長", threshold=100),
+        FilterRule("~$", "startsWith", "skip", "暫存檔案"),
+    )
+
+    def __init__(self, whitelist_patterns: Iterable[str]) -> None:
+        self.rules: List[FilterRule] = list(self.DEFAULT_RULES)
+        self.whitelist_patterns = tuple(whitelist_patterns)
+
+    def should_skip(self, file_name: str, file_size: int) -> bool:
+        """Return True if file should be skipped as a system file."""
+
+        for rule in self.rules:
+            if self._matches(rule, file_name):
+                return True
+        return file_size < 1
+
+    def is_whitelisted(self, file_name: str) -> bool:
+        """Return True if filename matches whitelist patterns."""
+
+        return any(pattern in file_name for pattern in self.whitelist_patterns)
+
+    def add_rule(self, rule: FilterRule) -> None:
+        self.rules.append(rule)
+
+    @staticmethod
+    def _matches(rule: FilterRule, file_name: str) -> bool:
+        if rule.rule_type == "contains":
+            return rule.pattern in file_name
+        if rule.rule_type == "startsWith":
+            return file_name.startswith(rule.pattern)
+        if rule.rule_type == "equals":
+            return file_name == rule.pattern
+        if rule.rule_type == "length" and rule.threshold is not None:
+            return len(file_name) > rule.threshold
+        return False
+

--- a/auto_organizer/mover.py
+++ b/auto_organizer/mover.py
@@ -1,0 +1,55 @@
+"""Safe file moving helpers."""
+
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+from typing import Optional
+
+from .config import DuplicateStrategy, FileInfo
+
+
+class FileMover:
+    """Move files while respecting duplicate handling strategies."""
+
+    def __init__(self, strategy: DuplicateStrategy) -> None:
+        self.strategy = strategy
+
+    def move(self, file_info: FileInfo, destination: Path) -> Optional[Path]:
+        destination.mkdir(parents=True, exist_ok=True)
+        target = destination / file_info.file_name
+
+        if target.exists():
+            if self.strategy == DuplicateStrategy.SKIP:
+                return None
+            if self.strategy == DuplicateStrategy.RENAME:
+                target = self._generate_unique_name(destination, file_info.file_name)
+            elif self.strategy == DuplicateStrategy.OVERWRITE:
+                if target.is_file():
+                    target.unlink()
+
+        shutil.move(str(file_info.file_path), str(target))
+        return target
+
+    def transactional_move(self, file_info: FileInfo, destination: Path) -> Optional[Path]:
+        marker = destination / ".temp_moving"
+        destination.mkdir(parents=True, exist_ok=True)
+        marker.touch(exist_ok=True)
+        try:
+            result = self.move(file_info, destination)
+            return result
+        finally:
+            if marker.exists():
+                marker.unlink()
+
+    @staticmethod
+    def _generate_unique_name(destination: Path, file_name: str) -> Path:
+        base = Path(file_name)
+        stem = base.stem
+        suffix = base.suffix
+        counter = 1
+        candidate = destination / file_name
+        while candidate.exists() and counter < 1000:
+            candidate = destination / f"{stem}_{counter}{suffix}"
+            counter += 1
+        return candidate

--- a/auto_organizer/organizer.py
+++ b/auto_organizer/organizer.py
@@ -1,0 +1,94 @@
+"""Main AutoOrganizer orchestration."""
+
+from __future__ import annotations
+
+import uuid
+from collections import defaultdict
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, Iterable, List, Optional
+
+from .classifier import ClassificationEngine
+from .config import FileInfo, OrganizeOptions, OrganizeResult, OrganizeTask
+from .filters import SystemFileFilter
+from .mover import FileMover
+from .report import ReportBuilder
+from .scanner import FileScanner
+
+
+class AutoOrganizer:
+    """Coordinate scanning, filtering, classification, and moving."""
+
+    def __init__(self, options: Optional[OrganizeOptions] = None) -> None:
+        self.options = options or OrganizeOptions()
+        self.filter = SystemFileFilter(self.options.whitelist_patterns)
+        self.scanner = FileScanner(self.options, self.filter)
+        self.classifier = ClassificationEngine()
+        self.mover = FileMover(self.options.duplicate_strategy)
+        self.reporter = ReportBuilder()
+
+    def load_custom_rules(self, path: Path) -> None:
+        self.classifier.load_custom_rules(path)
+
+    def organize(self, source_folders: Iterable[Path], target_folder: Path) -> OrganizeResult:
+        task = OrganizeTask(
+            task_id=str(uuid.uuid4()),
+            execution_time=datetime.now(),
+            source_folders=[Path(folder) for folder in source_folders],
+            target_folder=Path(target_folder),
+            options=self.options,
+        )
+
+        categorized: Dict[str, List[FileInfo]] = defaultdict(list)
+        errors: List[str] = []
+
+        for folder in task.source_folders:
+            for file_info in self.scanner.scan(folder):
+                task.statistics.total_files += 1
+                if file_info.is_system_file:
+                    task.statistics.skipped_items += 1
+                    continue
+
+                category, confidence = self.classifier.classify(file_info)
+                file_info.category = category
+                file_info.confidence = confidence
+
+                destination = target_folder / category
+
+                try:
+                    new_path = self.mover.transactional_move(file_info, destination)
+                except Exception as exc:  # noqa: BLE001
+                    error_message = f"Failed to move {file_info.file_path}: {exc}"
+                    errors.append(error_message)
+                    task.statistics.errors += 1
+                    file_info.process_status = "error"
+                    file_info.error_message = str(exc)
+                    continue
+
+                if new_path is None:
+                    task.statistics.skipped_items += 1
+                    file_info.process_status = "skipped"
+                    continue
+
+                if new_path != destination / file_info.file_name:
+                    task.statistics.duplicates += 1
+                task.statistics.processed_files += 1
+                file_info.process_status = "moved"
+                categorized[category].append(file_info)
+
+        if self.options.generate_report:
+            report = self.reporter.build(task.statistics, categorized)
+            report_path = target_folder / "AutoOrganizer_report.txt"
+            self.reporter.save(report, report_path)
+
+        return OrganizeResult(
+            success=task.statistics.errors == 0,
+            processed_files=task.statistics.processed_files,
+            skipped_files=task.statistics.skipped_items,
+            duplicates=task.statistics.duplicates,
+            errors=errors,
+            details={
+                category: [f.file_path for f in items]
+                for category, items in categorized.items()
+            },
+        )

--- a/auto_organizer/report.py
+++ b/auto_organizer/report.py
@@ -1,0 +1,27 @@
+"""Reporting helpers."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Dict, List
+
+from .config import FileInfo, Statistics
+
+
+class ReportBuilder:
+    """Generate simple textual reports for organization runs."""
+
+    def build(self, stats: Statistics, categorized: Dict[str, List[FileInfo]]) -> str:
+        lines = ["AutoOrganizer Report", "===================", ""]
+        lines.append(f"Total files scanned: {stats.total_files}")
+        lines.append(f"Processed files: {stats.processed_files}")
+        lines.append(f"Skipped items: {stats.skipped_items}")
+        lines.append(f"Duplicates: {stats.duplicates}")
+        lines.append(f"Errors: {stats.errors}")
+        lines.append("")
+        for category, items in categorized.items():
+            lines.append(f"{category}: {len(items)} files")
+        return "\n".join(lines)
+
+    def save(self, report: str, path: Path) -> None:
+        path.write_text(report, encoding="utf-8")

--- a/auto_organizer/scanner.py
+++ b/auto_organizer/scanner.py
@@ -1,0 +1,68 @@
+"""Filesystem scanning utilities."""
+
+from __future__ import annotations
+
+import os
+from datetime import datetime
+from pathlib import Path
+from typing import Iterator, List
+
+from .config import FileInfo, OrganizeOptions
+from .filters import SystemFileFilter
+
+
+class FileScanner:
+    """Scan directories and collect metadata according to options."""
+
+    def __init__(self, options: OrganizeOptions, system_filter: SystemFileFilter) -> None:
+        self.options = options
+        self.system_filter = system_filter
+
+    def scan(self, folder: Path) -> List[FileInfo]:
+        """Scan a folder and return metadata for eligible files."""
+
+        files: List[FileInfo] = []
+        for info in self._iter_files(folder):
+            if self.system_filter.should_skip(info.file_name, info.file_size):
+                info.is_system_file = True
+                info.process_status = "skipped"
+                files.append(info)
+                continue
+
+            if self.system_filter.is_whitelisted(info.file_name):
+                info.is_system_file = False
+            files.append(info)
+        return files
+
+    def _iter_files(self, folder: Path) -> Iterator[FileInfo]:
+        stack: List[Path] = [folder]
+        while stack:
+            current = stack.pop()
+            if not current.exists():
+                continue
+            with os.scandir(current) as it:
+                for entry in it:
+                    if entry.is_symlink():
+                        continue
+                    if entry.is_dir():
+                        if self.options.recursive:
+                            stack.append(Path(entry.path))
+                        continue
+
+                    stats = entry.stat()
+                    yield FileInfo(
+                        file_path=Path(entry.path),
+                        file_name=entry.name,
+                        file_extension=Path(entry.name).suffix.lower(),
+                        file_size=stats.st_size,
+                        creation_date=_safe_datetime(stats.st_ctime),
+                        modification_date=_safe_datetime(stats.st_mtime),
+                        source_folder=current,
+                    )
+
+
+def _safe_datetime(timestamp: float) -> datetime:
+    try:
+        return datetime.fromtimestamp(timestamp)
+    except (OverflowError, OSError, ValueError):
+        return datetime.fromtimestamp(0)


### PR DESCRIPTION
## Summary
- add configuration, filtering, and scanning utilities that follow the design document
- implement classification, moving, reporting, and orchestration logic for AutoOrganizer
- provide a CLI entry point and ignore Python cache artifacts

## Testing
- python -m auto_organizer.cli --help
- python -m auto_organizer.cli sample/source --target sample/target
- python -m compileall auto_organizer

------
https://chatgpt.com/codex/tasks/task_e_68de66302668832ea5e0eb54931bc390