### PR TITLE
Fix case-insensitive keyword classification

### DIFF
--- a/auto_organizer/classifier.py
+++ b/auto_organizer/classifier.py
@@ -158,8 +158,10 @@ class ClassificationEngine:
         score = 0
         if rule.extensions and file_info.file_extension in rule.extensions:
             score += rule.priority
-        if rule.keywords and any(keyword in file_info.file_name for keyword in rule.keywords):
-            score += rule.priority + 5
+        if rule.keywords:
+            file_name = file_info.file_name.casefold()
+            if any(keyword.casefold() in file_name for keyword in rule.keywords):
+                score += rule.priority + 5
         if rule.min_size and file_info.file_size >= rule.min_size:
             score += max(5, rule.priority // 2)
         return score

--- a/tests/test_auto_organizer.py
+++ b/tests/test_auto_organizer.py
@@ -85,6 +85,33 @@ def test_classification_engine_scores_rules() -> None:
     assert score >= documents_rule.priority
 
 
+def test_classification_keywords_are_case_insensitive() -> None:
+    engine = ClassificationEngine()
+    keyword_rule = CategoryRule(
+        id="notes",
+        name="📝 筆記",
+        emoji="📝",
+        keywords=("notes",),
+        priority=15,
+    )
+    engine.rules[keyword_rule.id] = keyword_rule
+
+    file_info = FileInfo(
+        file_path=Path("dummy"),
+        file_name="Project_NOTES.txt",
+        file_extension=".txt",
+        file_size=512,
+        creation_date=None,
+        modification_date=None,
+        source_folder=Path("."),
+    )
+
+    category, score = engine.classify(file_info)
+
+    assert category == keyword_rule.name
+    assert score >= keyword_rule.priority
+
+
 def test_file_mover_duplicate_handling(tmp_path: Path) -> None:
     destination = tmp_path / "dest"
     destination.mkdir()


### PR DESCRIPTION
## Summary
- update the classification engine to evaluate keyword matches in a case-insensitive way
- add regression test covering keyword-based classification when filenames use different cases

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68dfdf0ab9b4832ea69f3caded321732