### PR TITLE
Add planner, mover, and CLI pipeline for AutoOrganizer

### DIFF
--- a/auto_organizer/classifier.py
+++ b/auto_organizer/classifier.py
@@ -1,66 +1,224 @@
-"""Rule-based classification engine skeleton."""
+"""Rule-based classification engine."""
 from __future__ import annotations
 
 from collections import OrderedDict
-from pathlib import Path
-from typing import Mapping
+import json
+import logging
+import mimetypes
+import re
+from typing import Iterable, Mapping, NamedTuple
 
 from .models import ClassificationResult, FileCandidate
 
-# Priority mapping inspired by the specification.
-_RULE_PRIORITY = OrderedDict(
-    {
-        "extension": 100,
-        "keyword": 80,
-        "mime": 60,
-        "magic": 70,
-        "size": 50,
-    }
-)
+LOGGER_NAME = "auto_organizer.classifier"
+
+
+class _Decision(NamedTuple):
+    weight: int
+    source: str
+    category: str
+    rationale: str
+
+
+_RULE_PRIORITY: Mapping[str, int] = {
+    "extension": 100,
+    "keyword": 80,
+    "size": 50,
+    "mime": 60,
+    "magic": 70,
+}
+
+
+def _normalise_suffix(suffix: str) -> str:
+    if not suffix:
+        return suffix
+    if not suffix.startswith("."):
+        return f".{suffix.lower()}"
+    return suffix.lower()
 
 
 class ClassificationEngine:
     """Classifies files into categories using configurable rules."""
 
-    def __init__(self, rules: Mapping[str, Mapping[str, str]] | None = None) -> None:
+    def __init__(
+        self,
+        rules: Mapping[str, object] | None = None,
+        *,
+        logger: logging.Logger | None = None,
+    ) -> None:
         self.rules = rules or {}
+        classification_rules = self.rules.get("classification") if isinstance(self.rules, Mapping) else None
+        if isinstance(classification_rules, Mapping):
+            self._rules = classification_rules
+        else:
+            self._rules = self.rules  # type: ignore[assignment]
+        self.default_category: str = self.rules.get("default_category", "uncategorized") if isinstance(self.rules, Mapping) else "uncategorized"
+        self.logger = logger or logging.getLogger(LOGGER_NAME)
         self._extension_cache: OrderedDict[str, str] = OrderedDict()
         self._cache_limit = 1000
 
     def classify(self, candidate: FileCandidate) -> ClassificationResult:
         """Classify a file and return a :class:`ClassificationResult`."""
 
-        category = self._classify_by_extension(candidate.path)
-        if category is None:
-            category = "uncategorized"
+        decisions: list[_Decision] = []
 
-        rationale = f"extension:{candidate.path.suffix or 'none'}"
-        confidence = 0.0
-        if category != "uncategorized":
-            confidence = _RULE_PRIORITY["extension"] / 100
+        extension_decision = self._classify_by_extension(candidate)
+        if extension_decision:
+            decisions.append(extension_decision)
 
-        return ClassificationResult(category=category, confidence=confidence, rationale=rationale)
+        keyword_decision = self._classify_by_keyword(candidate)
+        if keyword_decision:
+            decisions.append(keyword_decision)
 
-    def _classify_by_extension(self, path: Path) -> str | None:
-        suffix = path.suffix.lower()
+        size_decision = self._classify_by_size(candidate)
+        if size_decision:
+            decisions.append(size_decision)
+
+        mime_decision = self._classify_by_mime(candidate)
+        if mime_decision:
+            decisions.append(mime_decision)
+
+        magic_decision = self._classify_by_magic(candidate)
+        if magic_decision:
+            decisions.append(magic_decision)
+
+        if decisions:
+            decisions.sort(key=lambda d: (-d.weight, self._source_priority(d.source)))
+            best = decisions[0]
+            return ClassificationResult(
+                category=best.category,
+                confidence=min(best.weight / 100.0, 1.0),
+                rationale=f"{best.source}:{best.rationale}",
+            )
+
+        return ClassificationResult(
+            category=self.default_category,
+            confidence=0.0,
+            rationale="no-match",
+        )
+
+    # ------------------------------------------------------------------
+    # Individual classification helpers
+    def _classify_by_extension(self, candidate: FileCandidate) -> _Decision | None:
+        suffix = _normalise_suffix(candidate.path.suffix)
         if not suffix:
             return None
 
+        cached = self._extension_cache_get(suffix)
+        if cached:
+            return _Decision(_RULE_PRIORITY["extension"], "extension", cached, suffix)
+
+        extension_rules = self._rules.get("extension", {})
+        if isinstance(extension_rules, Mapping):
+            if suffix in extension_rules:
+                category = str(extension_rules[suffix])
+                self._remember_extension(suffix, category)
+                return _Decision(_RULE_PRIORITY["extension"], "extension", category, suffix)
+
+        return None
+
+    def _classify_by_keyword(self, candidate: FileCandidate) -> _Decision | None:
+        keyword_rules = self._rules.get("keyword")
+        if not isinstance(keyword_rules, Mapping):
+            return None
+        name = candidate.path.name.lower()
+        keywords = self._tokenise(name)
+        for keyword in keywords:
+            if keyword in keyword_rules:
+                category = str(keyword_rules[keyword])
+                return _Decision(_RULE_PRIORITY["keyword"], "keyword", category, keyword)
+        for pattern, category in keyword_rules.items():
+            if pattern in keywords:
+                continue
+            try:
+                if re.search(pattern, name):
+                    return _Decision(_RULE_PRIORITY["keyword"], "keyword", str(category), pattern)
+            except re.error:
+                self._log_debug("Invalid keyword pattern", pattern)
+        return None
+
+    def _classify_by_size(self, candidate: FileCandidate) -> _Decision | None:
+        size_rules = self._rules.get("size")
+        if not isinstance(size_rules, Iterable):
+            return None
+        for rule in size_rules:
+            if not isinstance(rule, Mapping):
+                continue
+            min_size = int(rule.get("min", 0)) if rule.get("min") is not None else None
+            max_size = int(rule.get("max")) if rule.get("max") is not None else None
+            category = rule.get("category")
+            if not category:
+                continue
+            if min_size is not None and candidate.size < min_size:
+                continue
+            if max_size is not None and candidate.size > max_size:
+                continue
+            return _Decision(_RULE_PRIORITY["size"], "size", str(category), json.dumps(rule, ensure_ascii=False))
+        return None
+
+    def _classify_by_mime(self, candidate: FileCandidate) -> _Decision | None:
+        mime_rules = self._rules.get("mime")
+        if not isinstance(mime_rules, Mapping):
+            return None
+        mime_type, _ = mimetypes.guess_type(str(candidate.path))
+        if not mime_type:
+            return None
+        for pattern, category in mime_rules.items():
+            pattern_str = str(pattern)
+            if mime_type == pattern_str or mime_type.startswith(pattern_str.rstrip("*")):
+                return _Decision(_RULE_PRIORITY["mime"], "mime", str(category), mime_type)
+        return None
+
+    def _classify_by_magic(self, candidate: FileCandidate) -> _Decision | None:
+        magic_rules = self._rules.get("magic")
+        if not isinstance(magic_rules, Mapping):
+            return None
+        try:
+            with candidate.path.open("rb") as fh:
+                header = fh.read(32)
+        except OSError:
+            self._log_debug("Unable to read file for magic", str(candidate.path))
+            return None
+        for pattern, category in magic_rules.items():
+            needle = self._parse_magic_pattern(str(pattern))
+            if needle and header.startswith(needle):
+                return _Decision(_RULE_PRIORITY["magic"], "magic", str(category), pattern)
+        return None
+
+    # ------------------------------------------------------------------
+    # Helpers
+    def _parse_magic_pattern(self, pattern: str) -> bytes | None:
+        if pattern.startswith("0x"):
+            try:
+                return bytes.fromhex(pattern[2:])
+            except ValueError:
+                self._log_debug("Invalid hex magic pattern", pattern)
+                return None
+        return pattern.encode("utf-8")
+
+    def _extension_cache_get(self, suffix: str) -> str | None:
         if suffix in self._extension_cache:
             category = self._extension_cache.pop(suffix)
             self._extension_cache[suffix] = category
             return category
-
-        category = None
-        extension_rules = self.rules.get("extension", {})
-        if suffix in extension_rules:
-            category = extension_rules[suffix]
-
-        if category:
-            self._remember_extension(suffix, category)
-        return category
+        return None
 
     def _remember_extension(self, suffix: str, category: str) -> None:
         self._extension_cache[suffix] = category
         if len(self._extension_cache) > self._cache_limit:
             self._extension_cache.popitem(last=False)
+
+    def _tokenise(self, name: str) -> set[str]:
+        tokens = set(filter(None, re.split(r"[^a-z0-9]+", name)))
+        return tokens
+
+    def _log_debug(self, message: str, detail: str) -> None:
+        if self.logger and self.logger.isEnabledFor(logging.DEBUG):
+            self.logger.debug("%s: %s", message, detail)
+
+    def _source_priority(self, source: str) -> int:
+        order = ["extension", "keyword", "magic", "mime", "size"]
+        try:
+            return order.index(source)
+        except ValueError:
+            return len(order)

--- a/auto_organizer/cli.py
+++ b/auto_organizer/cli.py
@@ -1,0 +1,181 @@
+"""Command line interface for AutoOrganizer."""
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+from .classifier import ClassificationEngine
+from .file_mover import FileMover
+from .file_scanner import FileScanner
+from .logger import configure_logging, log_event
+from .models import FileCandidate, FilterDecision, Plan, PlanItem, PlanSummary
+from .planner import Planner
+from .reports import generate_reports
+from .system_filter import SystemFilter
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(prog="autoorganizer", description="AutoOrganizer CLI")
+    parser.add_argument("--log", type=Path, help="Path to log file", default=None)
+    parser.add_argument("--log-level", default="INFO", help="Logging level (DEBUG, INFO, WARNING, ERROR)")
+    subparsers = parser.add_subparsers(dest="command")
+
+    dry_parser = subparsers.add_parser("dry-run", help="Perform a dry-run and generate plan.json")
+    dry_parser.add_argument("sources", nargs="+", help="Source directories to scan")
+    dry_parser.add_argument("--dst", required=True, help="Destination root directory")
+    dry_parser.add_argument("--rules", required=True, type=Path, help="Classification rules JSON")
+    dry_parser.add_argument("--plan", type=Path, default=Path("plan.json"), help="Output plan file")
+    dry_parser.add_argument("--conflict-strategy", choices=["rename", "skip", "overwrite"], default="rename")
+    dry_parser.add_argument("--report-dir", type=Path, default=Path("."), help="Directory for reports")
+
+    run_parser = subparsers.add_parser("run", help="Execute a previously generated plan")
+    run_parser.add_argument("--plan", required=True, type=Path, help="Plan JSON file")
+    run_parser.add_argument("--rollback", type=Path, default=Path("rollback.json"), help="Rollback file path")
+    run_parser.add_argument("--conflict-strategy", choices=["rename", "skip", "overwrite"], default="rename")
+    run_parser.add_argument("--report-dir", type=Path, default=Path("."), help="Directory for reports")
+
+    args = parser.parse_args(argv)
+    if not args.command:
+        parser.print_help()
+        return 1
+
+    level = getattr(logging, str(args.log_level).upper(), logging.INFO)
+    logger = configure_logging(args.log, level=level)
+
+    if args.command == "dry-run":
+        return _cmd_dry_run(args, logger)
+    if args.command == "run":
+        return _cmd_run(args, logger)
+
+    parser.print_help()
+    return 1
+
+
+def _cmd_dry_run(args: argparse.Namespace, logger: logging.Logger) -> int:
+    rules = _load_rules(args.rules)
+    filter_whitelist = rules.get("whitelist", []) if isinstance(rules, dict) else []
+    sensitive_keywords = rules.get("sensitive_keywords", []) if isinstance(rules, dict) else []
+
+    system_filter = SystemFilter(whitelist=filter_whitelist, sensitive_keywords=sensitive_keywords)
+    classifier = ClassificationEngine(rules)
+    planner = Planner(
+        scanner=FileScanner(logger=logger),
+        system_filter=system_filter,
+        classifier=classifier,
+        logger=logger,
+        conflict_strategy=args.conflict_strategy,
+    )
+
+    plan = planner.build_plan(args.sources, args.dst)
+    planner.save_plan(plan, args.plan)
+    generate_reports(plan, None, args.report_dir)
+
+    log_event(
+        logger,
+        level=logging.INFO,
+        action="cli.dry_run",
+        message="Dry-run completed",
+        extra={
+            "plan": str(args.plan),
+            "report_dir": str(args.report_dir),
+            "planned": plan.summary.planned,
+            "skipped": plan.summary.skipped,
+        },
+    )
+    return 0
+
+
+def _cmd_run(args: argparse.Namespace, logger: logging.Logger) -> int:
+    plan = _load_plan(args.plan)
+    mover = FileMover(logger=logger, conflict_strategy=args.conflict_strategy)
+    summary = mover.execute_plan(plan.items, args.rollback)
+    generate_reports(plan, summary, args.report_dir)
+    log_event(
+        logger,
+        level=logging.INFO,
+        action="cli.run",
+        message="Run completed",
+        extra={
+            "plan": str(args.plan),
+            "rollback": str(args.rollback),
+            "processed": summary.processed,
+            "succeeded": summary.succeeded,
+            "skipped": summary.skipped,
+            "failed": summary.failed,
+        },
+    )
+    return 0 if summary.failed == 0 else 2
+
+
+def _load_rules(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _load_plan(path: Path) -> Plan:
+    raw = json.loads(path.read_text(encoding="utf-8"))
+    items = [
+        PlanItem(
+            source=Path(item["source"]),
+            destination=Path(item["destination"]),
+            operation=item["operation"],
+            same_volume=bool(item.get("same_volume", True)),
+            size=int(item.get("size", 0)),
+            conflict=bool(item.get("conflict", False)),
+            estimated_ms=item.get("estimated_ms"),
+            hash_digest=item.get("hash_digest"),
+            category=item.get("category"),
+            confidence=item.get("confidence"),
+            rationale=item.get("rationale"),
+            flags=set(item.get("flags", [])),
+        )
+        for item in raw.get("items", [])
+    ]
+    summary_data = raw.get("summary", {})
+    summary = PlanSummary(
+        total_candidates=int(summary_data.get("total_candidates", len(items))),
+        planned=int(summary_data.get("planned", len(items))),
+        skipped=int(summary_data.get("skipped", 0)),
+        total_bytes=int(summary_data.get("total_bytes", 0)),
+        categories=dict(summary_data.get("categories", {})),
+    )
+    skipped_entries = []
+    for entry in raw.get("skipped", []):
+        candidate = FileCandidate(
+            path=Path(entry.get("path", "")),
+            size=int(entry.get("size", 0)),
+            modified_at=datetime.utcnow(),
+        )
+        skipped_entries.append(
+            FilterDecision(
+                candidate=candidate,
+                should_skip=bool(entry.get("should_skip", True)),
+                reason=entry.get("reason"),
+                flags=set(entry.get("flags", [])),
+            )
+        )
+    plan = Plan(
+        sources=[str(src) for src in raw.get("sources", [])],
+        destination_root=Path(raw.get("destination_root", ".")),
+        items=items,
+        skipped=skipped_entries,
+        summary=summary,
+        generated_at=_parse_datetime(raw.get("generated_at")),
+    )
+    return plan
+
+
+def _parse_datetime(value: str | None) -> datetime:
+    if not value:
+        return datetime.utcnow()
+    try:
+        return datetime.fromisoformat(value.replace("Z", ""))
+    except ValueError:
+        return datetime.utcnow()
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/auto_organizer/file_mover.py
+++ b/auto_organizer/file_mover.py
@@ -1,50 +1,225 @@
-"""Safe file movement strategies."""
+"""Safe file movement strategies implementing the execution phase."""
 from __future__ import annotations
 
+import hashlib
+import json
 import logging
-import shutil
+import os
 from pathlib import Path
+from typing import Iterable
 
 from .logger import log_event
-from .models import PlanItem
+from .models import ExecutionSummary, PlanItem, RollbackStep
+
+LOGGER_NAME = "auto_organizer.mover"
+_BUFFER_SIZE = 1024 * 1024
+
+
+class ConflictError(RuntimeError):
+    """Raised when a conflict prevents executing a plan item."""
+
+
+class VerificationError(RuntimeError):
+    """Raised when SHA-256 verification fails."""
 
 
 class FileMover:
     """Execute move or copy operations following safety rules."""
 
-    def __init__(self, logger: logging.Logger) -> None:
-        self.logger = logger
+    def __init__(
+        self,
+        *,
+        logger: logging.Logger | None = None,
+        conflict_strategy: str = "rename",
+    ) -> None:
+        self.logger = logger or logging.getLogger(LOGGER_NAME)
+        if conflict_strategy not in {"rename", "skip", "overwrite"}:
+            raise ValueError("conflict_strategy must be rename/skip/overwrite")
+        self.conflict_strategy = conflict_strategy
 
-    def execute(self, plan_item: PlanItem) -> None:
-        """Execute a :class:`PlanItem`. Currently implements atomic rename and copy."""
+    # ------------------------------------------------------------------
+    def execute_plan(
+        self,
+        plan_items: Iterable[PlanItem],
+        rollback_path: Path,
+    ) -> ExecutionSummary:
+        """Execute all plan items and persist rollback instructions."""
 
-        if plan_item.operation == "rename":
-            self._rename(plan_item)
-        elif plan_item.operation == "copy":
-            self._copy(plan_item)
-        else:
-            raise ValueError(f"Unsupported operation: {plan_item.operation}")
+        rollback_steps: list[RollbackStep] = []
+        processed = 0
+        succeeded = 0
+        skipped = 0
+        failed = 0
+        bytes_processed = 0
+        errors: list[str] = []
 
-    def _rename(self, plan_item: PlanItem) -> None:
-        destination = plan_item.destination
-        destination.parent.mkdir(parents=True, exist_ok=True)
-        Path(plan_item.source).rename(destination)
-        log_event(
-            self.logger,
-            level=logging.INFO,
-            action="move.rename",
-            message=f"Moved {plan_item.source} -> {destination}",
-            bytes_processed=plan_item.size,
+        for item in plan_items:
+            processed += 1
+            try:
+                if item.flags and "conflict" in item.flags and self.conflict_strategy == "skip":
+                    skipped += 1
+                    log_event(
+                        self.logger,
+                        level=logging.WARNING,
+                        action="move.skip",
+                        message=f"Skipping {item.source} due to conflict flag",
+                        extra={"destination": str(item.destination)},
+                    )
+                    continue
+
+                step = self._execute_item(item)
+                rollback_steps.append(step)
+                succeeded += 1
+                bytes_processed += item.size
+            except ConflictError as exc:
+                skipped += 1
+                log_event(
+                    self.logger,
+                    level=logging.WARNING,
+                    action="move.conflict",
+                    message=str(exc),
+                    extra={"source": str(item.source), "destination": str(item.destination)},
+                )
+            except Exception as exc:  # pragma: no cover - defensive
+                failed += 1
+                message = f"Failed to move {item.source}: {exc}"
+                errors.append(message)
+                log_event(
+                    self.logger,
+                    level=logging.ERROR,
+                    action="move.error",
+                    message=message,
+                    extra={"source": str(item.source), "destination": str(item.destination)},
+                )
+
+        self._write_rollback(rollback_steps, rollback_path)
+
+        return ExecutionSummary(
+            processed=processed,
+            succeeded=succeeded,
+            skipped=skipped,
+            failed=failed,
+            bytes_processed=bytes_processed,
+            errors=errors,
         )
 
-    def _copy(self, plan_item: PlanItem) -> None:
-        destination = plan_item.destination
+    # ------------------------------------------------------------------
+    def _execute_item(self, item: PlanItem) -> RollbackStep:
+        destination = item.destination
         destination.parent.mkdir(parents=True, exist_ok=True)
-        shutil.copy2(plan_item.source, destination)
-        log_event(
-            self.logger,
-            level=logging.INFO,
-            action="move.copy",
-            message=f"Copied {plan_item.source} -> {destination}",
-            bytes_processed=plan_item.size,
-        )
+
+        if destination.exists():
+            if self.conflict_strategy == "skip":
+                raise ConflictError(f"Destination already exists: {destination}")
+            if self.conflict_strategy == "rename":
+                destination = self._next_available(destination)
+            elif self.conflict_strategy == "overwrite":
+                log_event(
+                    self.logger,
+                    level=logging.INFO,
+                    action="move.overwrite",
+                    message=f"Overwriting {destination}",
+                )
+
+        if item.operation == "rename":
+            actual_destination = destination
+            self._atomic_rename(item.source, actual_destination)
+            log_event(
+                self.logger,
+                level=logging.INFO,
+                action="move.rename",
+                message=f"Moved {item.source} -> {actual_destination}",
+                bytes_processed=item.size,
+            )
+            return RollbackStep(
+                source=actual_destination,
+                destination=item.source,
+                operation="rename",
+            )
+
+        if item.operation == "copy":
+            actual_destination = destination
+            digest = self._copy_with_verification(item.source, actual_destination)
+            item.hash_digest = digest
+            log_event(
+                self.logger,
+                level=logging.INFO,
+                action="move.copy",
+                message=f"Copied {item.source} -> {actual_destination}",
+                bytes_processed=item.size,
+                extra={"hash": digest},
+            )
+            self._delete_source(item.source)
+            return RollbackStep(
+                source=actual_destination,
+                destination=item.source,
+                operation="restore",
+            )
+
+        raise ValueError(f"Unsupported operation: {item.operation}")
+
+    def _atomic_rename(self, source: Path, destination: Path) -> None:
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        os.replace(source, destination)
+
+    def _copy_with_verification(self, source: Path, destination: Path) -> str:
+        temp_destination = destination.with_suffix(destination.suffix + ".ao_tmp")
+        hasher = hashlib.sha256()
+        with source.open("rb") as src, temp_destination.open("wb") as dst:
+            while True:
+                chunk = src.read(_BUFFER_SIZE)
+                if not chunk:
+                    break
+                dst.write(chunk)
+                hasher.update(chunk)
+            dst.flush()
+            os.fsync(dst.fileno())
+        source_digest = hasher.hexdigest()
+        dest_digest = self._sha256(temp_destination)
+        if source_digest != dest_digest:
+            temp_destination.unlink(missing_ok=True)
+            raise VerificationError("SHA-256 mismatch after copy")
+        os.replace(temp_destination, destination)
+        return source_digest
+
+    def _sha256(self, path: Path) -> str:
+        hasher = hashlib.sha256()
+        with path.open("rb") as fh:
+            while True:
+                chunk = fh.read(_BUFFER_SIZE)
+                if not chunk:
+                    break
+                hasher.update(chunk)
+        return hasher.hexdigest()
+
+    def _delete_source(self, source: Path) -> None:
+        source.unlink()
+
+    def _next_available(self, destination: Path) -> Path:
+        suffix = 1
+        candidate = destination
+        while candidate.exists():
+            candidate = destination.with_name(f"{destination.stem} ({suffix}){destination.suffix}")
+            suffix += 1
+        return candidate
+
+    def _write_rollback(self, steps: list[RollbackStep], rollback_path: Path) -> None:
+        data = [
+            {"operation": step.operation, "from": str(step.source), "to": str(step.destination)}
+            for step in steps
+        ]
+        rollback_path.parent.mkdir(parents=True, exist_ok=True)
+        rollback_path.write_text(json.dumps(data, indent=2, ensure_ascii=False), encoding="utf-8")
+
+        script_path = rollback_path.with_suffix(".sh")
+        lines = ["#!/bin/sh", "set -euo pipefail"]
+        for step in steps:
+            if step.operation == "rename":
+                lines.append(f"mv \"{step.source}\" \"{step.destination}\"")
+            elif step.operation == "restore":
+                lines.append(f"cp -p \"{step.source}\" \"{step.destination}\"")
+        script_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+        script_path.chmod(0o755)
+
+
+__all__ = ["FileMover", "ConflictError", "VerificationError"]

--- a/auto_organizer/logger.py
+++ b/auto_organizer/logger.py
@@ -3,31 +3,90 @@ from __future__ import annotations
 
 import json
 import logging
-from datetime import datetime
+from logging.handlers import RotatingFileHandler
 from pathlib import Path
 from typing import Any
 
+_HOME = Path.home()
 _LOG_FORMAT = "%(message)s"
+_MAX_BYTES = 10 * 1024 * 1024
+_BACKUP_COUNT = 5
 
 
-def configure_logging(log_path: Path | None = None, level: int = logging.INFO) -> logging.Logger:
+def _sanitize(value: str) -> str:
+    """Replace home directory with ``~/`` to protect privacy."""
+
+    try:
+        path = Path(value)
+    except TypeError:
+        return value
+    try:
+        value_str = str(path)
+        home_str = str(_HOME)
+        if value_str.startswith(home_str):
+            remainder = value_str[len(home_str):]
+            if remainder.startswith(('/', '\\')):
+                remainder = remainder[1:]
+            return f"~/{remainder}" if remainder else "~"
+        return value_str
+    except Exception:  # pragma: no cover - defensive
+        return value
+
+
+def configure_logging(
+    log_path: Path | None = None,
+    *,
+    level: int = logging.INFO,
+    max_bytes: int = _MAX_BYTES,
+    backup_count: int = _BACKUP_COUNT,
+) -> logging.Logger:
     """Configure and return the root logger used throughout the application."""
 
     logger = logging.getLogger("auto_organizer")
-    if logger.handlers:
-        return logger
-
     logger.setLevel(level)
-    handler: logging.Handler
+    logger.propagate = False
+
+    if logger.handlers:
+        if log_path:
+            for handler in list(logger.handlers):
+                logger.removeHandler(handler)
+                handler.close()
+        else:
+            for handler in logger.handlers:
+                handler.setLevel(level)
+            return logger
+
     if log_path:
         log_path.parent.mkdir(parents=True, exist_ok=True)
-        handler = logging.FileHandler(log_path, encoding="utf-8")
+        handler: logging.Handler = RotatingFileHandler(
+            log_path,
+            maxBytes=max_bytes,
+            backupCount=backup_count,
+            encoding="utf-8",
+        )
     else:
         handler = logging.StreamHandler()
 
+    handler.setLevel(level)
     handler.setFormatter(logging.Formatter(_LOG_FORMAT))
     logger.addHandler(handler)
     return logger
+
+
+def _prepare_payload(data: dict[str, Any]) -> dict[str, Any]:
+    sanitized: dict[str, Any] = {}
+    for key, value in data.items():
+        if isinstance(value, str):
+            sanitized[key] = _sanitize(value)
+        elif isinstance(value, dict):
+            sanitized[key] = _prepare_payload(value)
+        elif isinstance(value, (list, tuple)):
+            sanitized[key] = [
+                _sanitize(item) if isinstance(item, str) else item for item in value
+            ]
+        else:
+            sanitized[key] = value
+    return sanitized
 
 
 def log_event(
@@ -45,10 +104,10 @@ def log_event(
     """Emit a structured JSON log entry following the specification."""
 
     payload: dict[str, Any] = {
-        "ts": datetime.utcnow().isoformat(timespec="milliseconds") + "Z",
+        "ts": _utcnow_iso(),
         "level": logging.getLevelName(level),
         "action": action,
-        "message": message,
+        "message": _sanitize(message),
     }
     if task_id is not None:
         payload["taskId"] = task_id
@@ -59,6 +118,15 @@ def log_event(
     if duration_ms is not None:
         payload["ms"] = duration_ms
     if extra:
-        payload.update(extra)
+        payload.update(_prepare_payload(extra))
 
     logger.log(level, json.dumps(payload, ensure_ascii=False))
+
+
+def _utcnow_iso() -> str:
+    from datetime import datetime
+
+    return datetime.utcnow().isoformat(timespec="milliseconds") + "Z"
+
+
+__all__ = ["configure_logging", "log_event"]

--- a/auto_organizer/models.py
+++ b/auto_organizer/models.py
@@ -19,6 +19,50 @@ class FileCandidate:
 
 
 @dataclass(slots=True)
+class FilterDecision:
+    """Decision returned by :mod:`system_filter` for a candidate."""
+
+    candidate: FileCandidate
+    should_skip: bool
+    reason: str | None = None
+    flags: set[str] = field(default_factory=set)
+
+    def to_dict(self) -> dict[str, object]:
+        """Serialize the decision for JSON output."""
+
+        return {
+            "path": str(self.candidate.path),
+            "should_skip": self.should_skip,
+            "reason": self.reason,
+            "flags": sorted(self.flags),
+            "size": self.candidate.size,
+        }
+
+
+@dataclass(slots=True)
+class PlanSummary:
+    """Aggregated statistics for a generated plan."""
+
+    total_candidates: int
+    planned: int
+    skipped: int
+    total_bytes: int
+    categories: dict[str, int] = field(default_factory=dict)
+
+
+@dataclass(slots=True)
+class Plan:
+    """Full representation of a dry-run plan."""
+
+    sources: Sequence[str]
+    destination_root: Path
+    items: list[PlanItem]
+    skipped: list[FilterDecision]
+    summary: PlanSummary
+    generated_at: datetime
+
+
+@dataclass(slots=True)
 class FileScanOptions:
     """Configuration options for the :class:`~auto_organizer.file_scanner.FileScanner`."""
 
@@ -64,3 +108,28 @@ class PlanItem:
     conflict: bool
     estimated_ms: float | None = None
     hash_digest: str | None = None
+    category: str | None = None
+    confidence: float | None = None
+    rationale: str | None = None
+    flags: set[str] = field(default_factory=set)
+
+
+@dataclass(slots=True)
+class RollbackStep:
+    """Action that can undo a move performed by the mover."""
+
+    source: Path
+    destination: Path
+    operation: str
+
+
+@dataclass(slots=True)
+class ExecutionSummary:
+    """Aggregated statistics produced by the mover."""
+
+    processed: int
+    succeeded: int
+    skipped: int
+    failed: int
+    bytes_processed: int
+    errors: list[str] = field(default_factory=list)

--- a/auto_organizer/planner.py
+++ b/auto_organizer/planner.py
@@ -1,0 +1,230 @@
+"""Planner component responsible for dry-run plan generation."""
+from __future__ import annotations
+
+import json
+import logging
+from collections import Counter
+from dataclasses import asdict
+from datetime import datetime
+from pathlib import Path
+from typing import Sequence
+
+from .classifier import ClassificationEngine
+from .file_scanner import FileScanner
+from .logger import log_event
+from .models import (
+    ClassificationResult,
+    FileCandidate,
+    FilterDecision,
+    Plan,
+    PlanItem,
+    PlanSummary,
+)
+from .system_filter import SystemFilter
+
+LOGGER_NAME = "auto_organizer.planner"
+_DEFAULT_THROUGHPUT = 50 * 1024 * 1024  # 50 MB/s optimistic dry-run estimation
+
+
+class Planner:
+    """Aggregate scanner, filter and classifier to produce a plan."""
+
+    def __init__(
+        self,
+        *,
+        scanner: FileScanner | None = None,
+        system_filter: SystemFilter | None = None,
+        classifier: ClassificationEngine | None = None,
+        logger: logging.Logger | None = None,
+        throughput_bytes_per_sec: int = _DEFAULT_THROUGHPUT,
+        conflict_strategy: str = "rename",
+    ) -> None:
+        self.scanner = scanner or FileScanner()
+        self.filter = system_filter or SystemFilter()
+        self.classifier = classifier or ClassificationEngine()
+        self.logger = logger or logging.getLogger(LOGGER_NAME)
+        self.throughput = max(1, throughput_bytes_per_sec)
+        if conflict_strategy not in {"rename", "skip", "overwrite"}:
+            raise ValueError("conflict_strategy must be rename/skip/overwrite")
+        self.conflict_strategy = conflict_strategy
+
+    # ------------------------------------------------------------------
+    # Public API
+    def build_plan(self, sources: Sequence[str | Path], destination_root: str | Path) -> Plan:
+        """Perform a dry-run, returning a :class:`~auto_organizer.models.Plan`."""
+
+        scan_result = self.scanner.scan(sources)
+        decisions = list(self.filter.iter_decisions(scan_result.candidates))
+        planned_items: list[PlanItem] = []
+        skipped: list[FilterDecision] = []
+        categories: Counter[str] = Counter()
+        total_bytes = 0
+
+        dest_root_path = Path(destination_root).expanduser().resolve()
+
+        for decision in decisions:
+            if decision.should_skip:
+                skipped.append(decision)
+                log_event(
+                    self.logger,
+                    level=logging.INFO,
+                    action="plan.skip",
+                    message=f"Skip {decision.candidate.path}",
+                    extra={
+                        "path": str(decision.candidate.path),
+                        "reason": decision.reason,
+                        "flags": sorted(decision.flags),
+                    },
+                )
+                continue
+
+            classification = self.classifier.classify(decision.candidate)
+            destination = self._resolve_destination(dest_root_path, decision.candidate, classification)
+            final_destination, conflict_detected, skipped_due_to_conflict = self._handle_conflict(destination)
+            if skipped_due_to_conflict:
+                skipped.append(
+                    FilterDecision(
+                        candidate=decision.candidate,
+                        should_skip=True,
+                        reason="conflict",
+                        flags={"conflict"},
+                    )
+                )
+                continue
+
+            same_volume = self._same_volume(decision.candidate.path, final_destination)
+            operation = "rename" if same_volume else "copy"
+            estimated_ms = (decision.candidate.size / self.throughput) * 1000.0
+            total_bytes += decision.candidate.size
+
+            plan_item = PlanItem(
+                source=decision.candidate.path,
+                destination=final_destination,
+                operation=operation,
+                same_volume=same_volume,
+                size=decision.candidate.size,
+                conflict=conflict_detected,
+                estimated_ms=estimated_ms,
+                category=classification.category,
+                confidence=classification.confidence,
+                rationale=classification.rationale,
+                flags=decision.flags,
+            )
+            planned_items.append(plan_item)
+            categories[classification.category] += 1
+
+            log_event(
+                self.logger,
+                level=logging.INFO,
+                action="plan.item",
+                message=f"Planned {decision.candidate.path} -> {final_destination}",
+                extra={
+                    "operation": operation,
+                    "category": classification.category,
+                    "confidence": classification.confidence,
+                    "conflict": conflict_detected,
+                },
+            )
+
+        summary = PlanSummary(
+            total_candidates=len(decisions),
+            planned=len(planned_items),
+            skipped=len(skipped),
+            total_bytes=total_bytes,
+            categories=dict(categories),
+        )
+
+        plan = Plan(
+            sources=[str(Path(src).expanduser()) for src in sources],
+            destination_root=dest_root_path,
+            items=planned_items,
+            skipped=skipped,
+            summary=summary,
+            generated_at=datetime.utcnow(),
+        )
+        return plan
+
+    def save_plan(self, plan: Plan, path: str | Path) -> None:
+        """Persist plan information as JSON."""
+
+        payload = self._plan_to_dict(plan)
+        target = Path(path)
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(json.dumps(payload, indent=2, ensure_ascii=False), encoding="utf-8")
+
+    # ------------------------------------------------------------------
+    # Helpers
+    def _plan_to_dict(self, plan: Plan) -> dict[str, object]:
+        return {
+            "generated_at": plan.generated_at.isoformat(timespec="seconds") + "Z",
+            "sources": list(plan.sources),
+            "destination_root": str(plan.destination_root),
+            "summary": {
+                "total_candidates": plan.summary.total_candidates,
+                "planned": plan.summary.planned,
+                "skipped": plan.summary.skipped,
+                "total_bytes": plan.summary.total_bytes,
+                "categories": plan.summary.categories,
+            },
+            "items": [self._plan_item_to_dict(item) for item in plan.items],
+            "skipped": [decision.to_dict() for decision in plan.skipped],
+        }
+
+    def _plan_item_to_dict(self, item: PlanItem) -> dict[str, object]:
+        payload = asdict(item)
+        payload["source"] = str(item.source)
+        payload["destination"] = str(item.destination)
+        payload["flags"] = sorted(item.flags)
+        return payload
+
+    def _resolve_destination(
+        self,
+        destination_root: Path,
+        candidate: FileCandidate,
+        classification: ClassificationResult,
+    ) -> Path:
+        rules = self.classifier.rules if isinstance(self.classifier.rules, dict) else {}
+        destinations = rules.get("destinations", {}) if isinstance(rules, dict) else {}
+        default_destination = rules.get("default_destination", "uncategorized") if isinstance(rules, dict) else "uncategorized"
+        sub_dir = destinations.get(classification.category, default_destination)
+        return destination_root.joinpath(sub_dir, candidate.path.name)
+
+    def _handle_conflict(self, destination: Path) -> tuple[Path, bool, bool]:
+        conflict = destination.exists()
+        if not conflict:
+            return destination, False, False
+
+        if self.conflict_strategy == "overwrite":
+            return destination, True, False
+
+        if self.conflict_strategy == "skip":
+            return destination, True, True
+
+        # rename strategy
+        suffix = 1
+        candidate = destination
+        stem = destination.stem
+        suffix_template = "{} ({}){}"
+        while candidate.exists():
+            candidate = destination.with_name(suffix_template.format(stem, suffix, destination.suffix))
+            suffix += 1
+        return candidate, True, False
+
+    def _same_volume(self, source: Path, destination: Path) -> bool:
+        try:
+            src_dev = source.stat().st_dev
+        except FileNotFoundError:
+            return False
+
+        target_parent = destination.parent
+        while not target_parent.exists() and target_parent != target_parent.parent:
+            target_parent = target_parent.parent
+
+        try:
+            dest_dev = target_parent.stat().st_dev
+        except FileNotFoundError:
+            return False
+        return src_dev == dest_dev
+
+
+__all__ = ["Planner"]

--- a/auto_organizer/reports.py
+++ b/auto_organizer/reports.py
@@ -1,0 +1,99 @@
+"""Reporting helpers for dry-run and execution phases."""
+from __future__ import annotations
+
+import json
+from datetime import datetime
+from pathlib import Path
+
+from .models import ExecutionSummary, Plan
+
+
+def generate_reports(plan: Plan, execution: ExecutionSummary | None, output_dir: Path) -> None:
+    """Generate ``report.json`` and ``report.txt`` files."""
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+    report_json = _build_json(plan, execution)
+    (output_dir / "report.json").write_text(json.dumps(report_json, indent=2, ensure_ascii=False), encoding="utf-8")
+    (output_dir / "report.txt").write_text(_build_text(report_json), encoding="utf-8")
+
+
+def _build_json(plan: Plan, execution: ExecutionSummary | None) -> dict[str, object]:
+    payload: dict[str, object] = {
+        "generated_at": datetime.utcnow().isoformat(timespec="seconds") + "Z",
+        "plan": {
+            "sources": list(plan.sources),
+            "destination_root": str(plan.destination_root),
+            "summary": {
+                "total_candidates": plan.summary.total_candidates,
+                "planned": plan.summary.planned,
+                "skipped": plan.summary.skipped,
+                "total_bytes": plan.summary.total_bytes,
+                "categories": plan.summary.categories,
+            },
+            "skipped": [decision.to_dict() for decision in plan.skipped],
+        },
+    }
+    if execution:
+        payload["execution"] = {
+            "processed": execution.processed,
+            "succeeded": execution.succeeded,
+            "skipped": execution.skipped,
+            "failed": execution.failed,
+            "bytes_processed": execution.bytes_processed,
+            "errors": execution.errors,
+        }
+    return payload
+
+
+def _build_text(payload: dict[str, object]) -> str:
+    plan_section = payload["plan"]
+    summary = plan_section["summary"]
+    lines = [
+        "AutoOrganizer Execution Report",
+        "================================",
+        f"Report generated: {payload['generated_at']}",
+        "",
+        "Plan Summary:",
+        f"  Sources       : {', '.join(plan_section['sources'])}",
+        f"  Destination   : {plan_section['destination_root']}",
+        f"  Candidates    : {summary['total_candidates']}",
+        f"  Planned       : {summary['planned']}",
+        f"  Skipped       : {summary['skipped']}",
+        f"  Total bytes   : {summary['total_bytes']}",
+    ]
+    categories = summary.get("categories", {})
+    if categories:
+        lines.append("  Categories    :")
+        for category, count in sorted(categories.items()):
+            lines.append(f"    - {category}: {count}")
+    skipped = plan_section.get("skipped", [])
+    if skipped:
+        lines.append("")
+        lines.append("Skipped Items:")
+        for entry in skipped[:10]:
+            lines.append(f"  - {entry['path']} ({entry.get('reason', 'unknown')})")
+        if len(skipped) > 10:
+            lines.append(f"    ... {len(skipped) - 10} more")
+    execution = payload.get("execution")
+    if execution:
+        lines.extend(
+            [
+                "",
+                "Execution Summary:",
+                f"  Processed     : {execution['processed']}",
+                f"  Succeeded     : {execution['succeeded']}",
+                f"  Skipped       : {execution['skipped']}",
+                f"  Failed        : {execution['failed']}",
+                f"  Bytes moved   : {execution['bytes_processed']}",
+            ]
+        )
+        errors = execution.get("errors", [])
+        if errors:
+            lines.append("  Errors:")
+            for err in errors:
+                lines.append(f"    - {err}")
+    lines.append("")
+    return "\n".join(lines)
+
+
+__all__ = ["generate_reports"]

--- a/auto_organizer/system_filter.py
+++ b/auto_organizer/system_filter.py
@@ -1,63 +1,155 @@
-"""System and sensitive file filtering logic."""
+"""System and sensitive file filtering logic following the specification."""
 from __future__ import annotations
 
 from pathlib import Path
 from typing import Iterable, Iterator
 
-from .models import FileCandidate
+from .models import FileCandidate, FilterDecision
 
 _DEFAULT_EXCLUDES = {
     ".DS_Store",
     "Thumbs.db",
     "__MACOSX",
     "__pycache__",
+    ".git",
+    ".svn",
+    "node_modules",
 }
+
+_TEMP_SUFFIXES = {".tmp", ".temp", ".part", ".partial"}
+_TEMP_PREFIXES = {"~$", "._"}
+
+_CLOUD_PLACEHOLDER_SUFFIXES = {".icloud", ".icloud~", ".onepkg", ".one"}
+_CLOUD_PLACEHOLDER_KEYWORDS = {"onedrive", "dropbox", "icloud"}
 
 _SENSITIVE_KEYWORDS = {
     "password",
     "密碼",
     "private",
     "機密",
+    "confidential",
+    "secret",
 }
+
+_DEVELOPER_FOLDERS = {"build", "dist", "venv", ".venv", "env", ".idea"}
 
 
 class SystemFilter:
     """Filter out files that should not be processed further."""
 
-    def __init__(self, *, whitelist: Iterable[str] | None = None) -> None:
+    def __init__(
+        self,
+        *,
+        whitelist: Iterable[str] | None = None,
+        sensitive_keywords: Iterable[str] | None = None,
+        max_name_length: int = 255,
+        skip_hidden: bool = True,
+        skip_empty: bool = True,
+        sensitive_action: str = "skip",
+    ) -> None:
         self.whitelist = {item.lower() for item in whitelist or []}
+        self.sensitive_keywords = {
+            *(keyword.lower() for keyword in sensitive_keywords or []),
+            *_SENSITIVE_KEYWORDS,
+        }
+        self.max_name_length = max_name_length
+        self.skip_hidden = skip_hidden
+        self.skip_empty = skip_empty
+        if sensitive_action not in {"skip", "flag"}:
+            raise ValueError("sensitive_action must be 'skip' or 'flag'")
+        self.sensitive_action = sensitive_action
+
+    def evaluate(self, candidate: FileCandidate) -> FilterDecision:
+        """Evaluate a candidate and return a :class:`FilterDecision`."""
+
+        flags: set[str] = set()
+        should_skip = False
+        reason: str | None = None
+        path = candidate.path
+
+        if self._is_whitelisted(path):
+            flags.add("whitelisted")
+            return FilterDecision(candidate, False, None, flags)
+
+        checks: list[tuple[bool, str, str]] = [
+            (self._is_cloud_placeholder(path, candidate.size), "cloud_placeholder", "cloud-placeholder"),
+            (self.skip_hidden and self._is_hidden(path), "hidden", "hidden"),
+            (self._is_system_file(path), "system", "system"),
+            (self._is_developer_path(path), "developer", "developer"),
+            (self._is_temporary(path), "temporary", "temporary"),
+            (self._is_name_too_long(path), "name_too_long", "long-name"),
+            (self.skip_empty and candidate.size == 0, "empty_file", "empty"),
+        ]
+
+        for condition, reason_token, flag in checks:
+            if condition:
+                flags.add(flag)
+                if reason is None:
+                    reason = reason_token
+                should_skip = True
+
+        sensitive_flag = self._contains_sensitive_keyword(path)
+        if sensitive_flag:
+            flags.add("sensitive")
+            if self.sensitive_action == "skip":
+                should_skip = True
+                if reason is None:
+                    reason = "sensitive_keyword"
+
+        return FilterDecision(candidate, should_skip, reason, flags)
 
     def filter_candidates(self, candidates: Iterable[FileCandidate]) -> Iterator[FileCandidate]:
         """Yield candidates that pass system and sensitive checks."""
 
         for candidate in candidates:
-            if self._is_whitelisted(candidate.path):
-                yield candidate
-                continue
+            decision = self.evaluate(candidate)
+            if not decision.should_skip:
+                yield decision.candidate
 
-            if self._is_system_file(candidate.path):
-                continue
+    def iter_decisions(self, candidates: Iterable[FileCandidate]) -> Iterator[FilterDecision]:
+        """Yield :class:`FilterDecision` for each candidate."""
 
-            if self._contains_sensitive_keyword(candidate.path):
-                candidate.tags.add("sensitive")
-                yield candidate
-                continue
-
-            yield candidate
+        for candidate in candidates:
+            yield self.evaluate(candidate)
 
     def _is_system_file(self, path: Path) -> bool:
         name = path.name
         if name in _DEFAULT_EXCLUDES:
             return True
-        if name.startswith("~$"):
-            return True
-        if path.suffix.lower() in {".tmp", ".temp"}:
+        if any(part in _DEFAULT_EXCLUDES for part in path.parts):
             return True
         return False
 
+    def _is_hidden(self, path: Path) -> bool:
+        return any(part.startswith(".") and part not in {"..", "."} for part in path.parts)
+
+    def _is_temporary(self, path: Path) -> bool:
+        name = path.name
+        if any(name.startswith(prefix) for prefix in _TEMP_PREFIXES):
+            return True
+        if any(name.endswith(suffix) for suffix in _TEMP_SUFFIXES):
+            return True
+        if name.endswith("~"):
+            return True
+        return False
+
+    def _is_developer_path(self, path: Path) -> bool:
+        return any(part.lower() in _DEVELOPER_FOLDERS for part in path.parts)
+
+    def _is_name_too_long(self, path: Path) -> bool:
+        return len(path.name.encode("utf-8")) > self.max_name_length
+
     def _contains_sensitive_keyword(self, path: Path) -> bool:
         name_lower = path.name.lower()
-        return any(keyword in name_lower for keyword in _SENSITIVE_KEYWORDS)
+        return any(keyword in name_lower for keyword in self.sensitive_keywords)
+
+    def _is_cloud_placeholder(self, path: Path, size: int) -> bool:
+        name_lower = path.name.lower()
+        if any(name_lower.endswith(suffix) for suffix in _CLOUD_PLACEHOLDER_SUFFIXES):
+            return True
+        if size == 0 and any(keyword in str(path).lower() for keyword in _CLOUD_PLACEHOLDER_KEYWORDS):
+            return True
+        return False
 
     def _is_whitelisted(self, path: Path) -> bool:
         if not self.whitelist:

--- a/auto_organizer/tests/conftest.py
+++ b/auto_organizer/tests/conftest.py
@@ -1,0 +1,8 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))

--- a/auto_organizer/tests/test_classifier.py
+++ b/auto_organizer/tests/test_classifier.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+from datetime import datetime
+from pathlib import Path
+
+from auto_organizer.classifier import ClassificationEngine
+from auto_organizer.models import FileCandidate
+
+
+def make_candidate(path: Path, size: int = 0) -> FileCandidate:
+    return FileCandidate(path=path, size=size, modified_at=datetime.utcnow())
+
+
+def test_extension_and_cache(tmp_path: Path) -> None:
+    rules = {
+        "classification": {
+            "extension": {".pdf": "documents"},
+        },
+        "default_category": "misc",
+    }
+    engine = ClassificationEngine(rules)
+    candidate = make_candidate(tmp_path / "report.pdf")
+    result = engine.classify(candidate)
+    assert result.category == "documents"
+    assert result.confidence == 1.0
+    # Second call should hit cache
+    result_cached = engine.classify(make_candidate(tmp_path / "another.pdf"))
+    assert result_cached.category == "documents"
+
+
+def test_keyword_and_size_rules(tmp_path: Path) -> None:
+    rules = {
+        "classification": {
+            "keyword": {"invoice": "finance"},
+            "size": [
+                {"max": 1024, "category": "small"},
+            ],
+        },
+        "default_category": "misc",
+    }
+    engine = ClassificationEngine(rules)
+    keyword_candidate = make_candidate(tmp_path / "invoice_2023.txt")
+    result_keyword = engine.classify(keyword_candidate)
+    assert result_keyword.category == "finance"
+    small_candidate = make_candidate(tmp_path / "blob", size=512)
+    result_size = engine.classify(small_candidate)
+    assert result_size.category == "small"
+
+
+def test_magic_and_mime_detection(tmp_path: Path) -> None:
+    pdf_path = tmp_path / "sample.pdf"
+    pdf_path.write_bytes(b"%PDF-1.4\ncontent")
+    rules = {
+        "classification": {
+            "extension": {},
+            "magic": {"%PDF-": "documents"},
+            "mime": {"text/plain": "text"},
+        },
+        "default_category": "misc",
+    }
+    engine = ClassificationEngine(rules)
+    pdf_candidate = make_candidate(pdf_path, size=pdf_path.stat().st_size)
+    result_pdf = engine.classify(pdf_candidate)
+    assert result_pdf.category == "documents"
+    text_path = tmp_path / "notes.txt"
+    text_path.write_text("notes", encoding="utf-8")
+    text_candidate = make_candidate(text_path, size=text_path.stat().st_size)
+    result_text = engine.classify(text_candidate)
+    assert result_text.category in {"text", "misc"}

--- a/auto_organizer/tests/test_cli_integration.py
+++ b/auto_organizer/tests/test_cli_integration.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from auto_organizer.cli import main
+
+
+def test_dry_run_then_run(tmp_path: Path) -> None:
+    source_dir = tmp_path / "source"
+    destination_root = tmp_path / "dest"
+    source_dir.mkdir()
+    destination_root.mkdir()
+    file_path = source_dir / "notes.txt"
+    file_path.write_text("hello world", encoding="utf-8")
+
+    rules = {
+        "classification": {
+            "extension": {".txt": "text"},
+        },
+        "destinations": {"text": "Text", "misc": "Misc"},
+        "default_destination": "Misc",
+        "default_category": "misc",
+    }
+    rules_path = tmp_path / "rules.json"
+    rules_path.write_text(json.dumps(rules), encoding="utf-8")
+
+    plan_path = tmp_path / "plan.json"
+    report_dir = tmp_path / "reports"
+
+    exit_code = main(
+        [
+            "dry-run",
+            str(source_dir),
+            "--dst",
+            str(destination_root),
+            "--rules",
+            str(rules_path),
+            "--plan",
+            str(plan_path),
+            "--report-dir",
+            str(report_dir),
+        ]
+    )
+    assert exit_code == 0
+    assert plan_path.exists()
+    plan_data = json.loads(plan_path.read_text(encoding="utf-8"))
+    assert plan_data["summary"]["planned"] == 1
+
+    rollback_path = tmp_path / "rollback.json"
+    exit_code_run = main(
+        [
+            "run",
+            "--plan",
+            str(plan_path),
+            "--rollback",
+            str(rollback_path),
+            "--report-dir",
+            str(report_dir),
+        ]
+    )
+    assert exit_code_run == 0
+    moved_path = destination_root / "Text" / "notes.txt"
+    assert moved_path.exists()
+    assert not file_path.exists()
+    report_json = report_dir / "report.json"
+    report_txt = report_dir / "report.txt"
+    assert report_json.exists()
+    assert report_txt.exists()
+    rollback_data = json.loads(rollback_path.read_text(encoding="utf-8"))
+    assert rollback_data[0]["operation"] in {"rename", "restore"}

--- a/auto_organizer/tests/test_file_mover.py
+++ b/auto_organizer/tests/test_file_mover.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+
+from auto_organizer.file_mover import FileMover
+from auto_organizer.models import PlanItem
+
+
+def make_logger(name: str = "auto_organizer.test") -> logging.Logger:
+    logger = logging.getLogger(name)
+    logger.handlers = []
+    logger.addHandler(logging.NullHandler())
+    logger.setLevel(logging.INFO)
+    return logger
+
+
+def test_rename_creates_rollback(tmp_path: Path) -> None:
+    source_dir = tmp_path / "src"
+    destination_dir = tmp_path / "dst"
+    source_dir.mkdir()
+    destination_dir.mkdir()
+    source_file = source_dir / "sample.txt"
+    source_file.write_text("content", encoding="utf-8")
+    plan_item = PlanItem(
+        source=source_file,
+        destination=destination_dir / "sample.txt",
+        operation="rename",
+        same_volume=True,
+        size=source_file.stat().st_size,
+        conflict=False,
+    )
+    mover = FileMover(logger=make_logger("auto_organizer.rename_test"))
+    rollback_path = tmp_path / "rollback.json"
+    summary = mover.execute_plan([plan_item], rollback_path)
+    assert summary.succeeded == 1
+    assert (destination_dir / "sample.txt").exists()
+    assert not source_file.exists()
+    data = json.loads(rollback_path.read_text(encoding="utf-8"))
+    assert data[0]["operation"] == "rename"
+    script = rollback_path.with_suffix(".sh").read_text(encoding="utf-8")
+    assert "mv" in script
+
+
+def test_copy_with_verification(tmp_path: Path) -> None:
+    source_dir = tmp_path / "src"
+    destination_dir = tmp_path / "dst"
+    source_dir.mkdir()
+    destination_dir.mkdir()
+    source_file = source_dir / "sample.bin"
+    source_file.write_bytes(b"binary-data" * 10)
+    plan_item = PlanItem(
+        source=source_file,
+        destination=destination_dir / "sample.bin",
+        operation="copy",
+        same_volume=False,
+        size=source_file.stat().st_size,
+        conflict=False,
+    )
+    mover = FileMover(logger=make_logger("auto_organizer.copy_test"))
+    rollback_path = tmp_path / "rollback_copy.json"
+    summary = mover.execute_plan([plan_item], rollback_path)
+    assert summary.succeeded == 1
+    assert (destination_dir / "sample.bin").exists()
+    assert not source_file.exists()
+    assert plan_item.hash_digest is not None
+    rollback = json.loads(rollback_path.read_text(encoding="utf-8"))
+    assert rollback[0]["operation"] == "restore"

--- a/auto_organizer/tests/test_logger.py
+++ b/auto_organizer/tests/test_logger.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+
+from auto_organizer.logger import configure_logging, log_event
+
+
+def test_log_event_sanitizes_home_directory(tmp_path: Path) -> None:
+    log_file = tmp_path / "auto.log"
+    logger = configure_logging(log_file, level=logging.INFO)
+    sensitive_path = Path.home() / "Documents" / "secret.txt"
+    log_event(
+        logger,
+        level=logging.INFO,
+        action="test",
+        message="Processing",
+        extra={"path": str(sensitive_path)},
+    )
+    for handler in logger.handlers:
+        handler.flush()
+    contents = log_file.read_text(encoding="utf-8").strip().splitlines()
+    assert contents
+    payload = json.loads(contents[-1])
+    assert payload["path"].startswith("~/")

--- a/auto_organizer/tests/test_system_filter.py
+++ b/auto_organizer/tests/test_system_filter.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+from datetime import datetime
+from pathlib import Path
+
+from auto_organizer.models import FileCandidate
+from auto_organizer.system_filter import SystemFilter
+
+
+def make_candidate(tmp_path: Path, name: str, size: int = 1) -> FileCandidate:
+    path = tmp_path / name
+    path.write_bytes(b"x" * size)
+    return FileCandidate(path=path, size=size, modified_at=datetime.utcnow())
+
+
+def test_hidden_file_is_skipped(tmp_path: Path) -> None:
+    candidate = make_candidate(tmp_path, ".hidden", size=0)
+    system_filter = SystemFilter()
+    decision = system_filter.evaluate(candidate)
+    assert decision.should_skip
+    assert decision.reason == "hidden"
+    assert "hidden" in decision.flags
+
+
+def test_whitelisted_file_bypasses_rules(tmp_path: Path) -> None:
+    candidate = make_candidate(tmp_path, ".hidden_doc")
+    system_filter = SystemFilter(whitelist=[str(candidate.path)])
+    decision = system_filter.evaluate(candidate)
+    assert not decision.should_skip
+    assert "whitelisted" in decision.flags
+
+
+def test_sensitive_keyword_flags_and_skips(tmp_path: Path) -> None:
+    candidate = make_candidate(tmp_path, "secret_password.txt")
+    system_filter = SystemFilter()
+    decision = system_filter.evaluate(candidate)
+    assert decision.should_skip
+    assert decision.reason == "sensitive_keyword"
+    assert "sensitive" in decision.flags
+
+
+def test_temporary_and_cloud_placeholder(tmp_path: Path) -> None:
+    candidate = make_candidate(tmp_path, "tempfile.tmp")
+    placeholder = make_candidate(tmp_path, "icloud.data.icloud", size=0)
+    system_filter = SystemFilter()
+    temp_decision = system_filter.evaluate(candidate)
+    cloud_decision = system_filter.evaluate(placeholder)
+    assert temp_decision.should_skip
+    assert "temporary" in temp_decision.flags
+    assert cloud_decision.should_skip
+    assert cloud_decision.reason == "cloud_placeholder"

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,35 @@
+# AutoOrganizer Architecture Notes
+
+## Planner / Mover / Logger Interaction
+
+```mermaid
+sequenceDiagram
+    participant CLI
+    participant Planner
+    participant Scanner
+    participant SystemFilter
+    participant Classifier
+    participant Mover
+    participant Logger
+
+    CLI->>Planner: build_plan(sources, dst)
+    Planner->>Scanner: scan(sources)
+    Scanner-->>Planner: candidates
+    Planner->>SystemFilter: evaluate(candidate)
+    SystemFilter-->>Planner: decision
+    Planner->>Classifier: classify(candidate)
+    Classifier-->>Planner: category/confidence
+    Planner-->>CLI: plan.json + report
+
+    CLI->>Mover: execute_plan(plan.items)
+    Mover->>Logger: log_event(move.start)
+    Mover->>Mover: rename/copy+verify
+    Mover->>Logger: log_event(move.done)
+    Mover-->>CLI: ExecutionSummary + rollback.json
+```
+
+The planner orchestrates scanning, filtering, and classification to produce a `plan.json`
+without touching the file system. When executing `run --plan`, the mover performs atomic
+renames on the same volume and safe copy+verify sequences across volumes. Every significant
+step emits structured JSON lines via the logger, which handles log rotation, home directory
+redaction, and log level control.

--- a/examples/plan.json
+++ b/examples/plan.json
@@ -1,0 +1,39 @@
+{
+  "generated_at": "2024-04-01T12:00:00Z",
+  "sources": ["/Users/example/Downloads"],
+  "destination_root": "/Users/example/Archive",
+  "summary": {
+    "total_candidates": 2,
+    "planned": 1,
+    "skipped": 1,
+    "total_bytes": 2048,
+    "categories": {
+      "documents": 1
+    }
+  },
+  "items": [
+    {
+      "source": "/Users/example/Downloads/report.pdf",
+      "destination": "/Users/example/Archive/Documents/report.pdf",
+      "operation": "rename",
+      "same_volume": true,
+      "size": 2048,
+      "conflict": false,
+      "estimated_ms": 10.5,
+      "hash_digest": null,
+      "category": "documents",
+      "confidence": 1.0,
+      "rationale": "extension:.pdf",
+      "flags": []
+    }
+  ],
+  "skipped": [
+    {
+      "path": "/Users/example/Downloads/.DS_Store",
+      "should_skip": true,
+      "reason": "system",
+      "flags": ["system"],
+      "size": 0
+    }
+  ]
+}

--- a/examples/report.json
+++ b/examples/report.json
@@ -1,0 +1,33 @@
+{
+  "generated_at": "2024-04-01T12:05:00Z",
+  "plan": {
+    "sources": ["/Users/example/Downloads"],
+    "destination_root": "/Users/example/Archive",
+    "summary": {
+      "total_candidates": 2,
+      "planned": 1,
+      "skipped": 1,
+      "total_bytes": 2048,
+      "categories": {
+        "documents": 1
+      }
+    },
+    "skipped": [
+      {
+        "path": "/Users/example/Downloads/.DS_Store",
+        "should_skip": true,
+        "reason": "system",
+        "flags": ["system"],
+        "size": 0
+      }
+    ]
+  },
+  "execution": {
+    "processed": 1,
+    "succeeded": 1,
+    "skipped": 0,
+    "failed": 0,
+    "bytes_processed": 2048,
+    "errors": []
+  }
+}

--- a/examples/report.txt
+++ b/examples/report.txt
@@ -1,0 +1,24 @@
+AutoOrganizer Execution Report
+================================
+Report generated: 2024-04-01T12:05:00Z
+
+Plan Summary:
+  Sources       : /Users/example/Downloads
+  Destination   : /Users/example/Archive
+  Candidates    : 2
+  Planned       : 1
+  Skipped       : 1
+  Total bytes   : 2048
+  Categories    :
+    - documents: 1
+
+Skipped Items:
+  - /Users/example/Downloads/.DS_Store (system)
+
+Execution Summary:
+  Processed     : 1
+  Succeeded     : 1
+  Skipped       : 0
+  Failed        : 0
+  Bytes moved   : 2048
+

--- a/examples/rollback.json
+++ b/examples/rollback.json
@@ -1,0 +1,7 @@
+[
+  {
+    "operation": "rename",
+    "from": "/Users/example/Archive/Documents/report.pdf",
+    "to": "/Users/example/Downloads/report.pdf"
+  }
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,9 @@ dev = [
     "pytest>=7.4",
 ]
 
+[project.scripts]
+autoorganizer = "auto_organizer.cli:main"
+
 [tool.pytest.ini_options]
 testpaths = ["auto_organizer/tests"]
 addopts = "-q"


### PR DESCRIPTION
## Summary
- implement full system filter and rule-based classification with caching
- add planner, mover, reporting, and CLI commands with JSON logging enhancements
- provide sample outputs, architecture docs, and unit/integration tests covering new modules

## Testing
- pytest --cov=auto_organizer --cov-report=term -q

------
https://chatgpt.com/codex/tasks/task_e_68e4f39feed4832eb2af9ac020137a35