### PR TITLE
feat(phase3): watcher event queue and dry-run

### DIFF
--- a/WATCHER.md
+++ b/WATCHER.md
@@ -1,0 +1,49 @@
+# Watcher Module
+
+The watcher subsystem delivers realtime filesystem monitoring with macOS
+FSEvents support and a cross-platform polling fallback. Events are merged and
+debounced before being evaluated in a dry-run that predicts AutoOrganizer move
+plans.
+
+## Architecture Overview
+
+- **Backends** – `RealtimeWatcher` automatically prefers the FSEvents backend on
+  macOS. When unavailable, it falls back to a lightweight polling backend that
+  scans watched paths at a configurable interval.
+- **Event Queue** – `auto_organizer.watcher.event_queue.EventQueue` merges rapid
+  successive events for the same path and prefers terminal states (for example,
+  delete beats modify). Queue flushing happens automatically based on the batch
+  interval or when the watcher stops.
+- **Dry-run** – `auto_organizer.watcher.dryrun.generate_move_plan` consumes
+  emitted events, classifies surviving files and emits `move_plan` entries with
+  `path`, `predicted_category`, `target`, `confidence`, and `conflict` flags. A
+  JSON helper (`render_move_plan_json`) serializes the dry-run preview.
+
+## Usage
+
+```python
+from auto_organizer.realtime_watcher import RealtimeWatcher
+from auto_organizer.watcher.dryrun import generate_move_plan, render_move_plan_json
+
+pending_batches: list[list[FileSystemEvent]] = []
+
+watcher = RealtimeWatcher(["~/Downloads"], callback=pending_batches.append)
+watcher.start()
+# ... allow events to accumulate ...
+watcher.stop()
+
+entries = generate_move_plan(
+    pending_batches[-1],
+    destination_root="~/Organized",
+    category_mapping={"docs": "Documents"},
+)
+print(render_move_plan_json(entries))
+```
+
+## /review Summary
+
+- Event queue merges duplicate events, prefers deletes/moves, and flushes via
+  debounce-aware batching.
+- Polling backend maintains parity with FSEvents behaviour for local testing.
+- Dry-run output now surfaces move plans as JSON-ready dictionaries.
+- Tests cover event queue merge semantics and dry-run predictions.

--- a/auto_organizer/tests/test_watcher_dryrun.py
+++ b/auto_organizer/tests/test_watcher_dryrun.py
@@ -1,0 +1,46 @@
+"""Tests for the watcher dry-run pipeline."""
+from __future__ import annotations
+
+from pathlib import Path
+
+from auto_organizer.classifier import ClassificationEngine
+from auto_organizer.watcher.dryrun import generate_move_plan, render_move_plan_json
+from auto_organizer.watcher.types import EventType, FileSystemEvent
+
+
+def test_generate_move_plan(tmp_path):
+    watched_file = tmp_path / "sample.txt"
+    watched_file.write_text("hello")
+
+    events = [FileSystemEvent(path=watched_file, event_type=EventType.CREATED)]
+
+    classifier = ClassificationEngine(rules={"extension": {".txt": "docs"}})
+    destination_root = tmp_path / "organized"
+
+    entries = generate_move_plan(
+        events,
+        destination_root=destination_root,
+        classifier=classifier,
+        category_mapping={"docs": "Documents"},
+    )
+
+    assert len(entries) == 1
+    entry = entries[0]
+    assert entry.path == str(watched_file)
+    assert entry.predicted_category == "docs"
+    assert entry.confidence == 1.0
+    expected_target = destination_root / "Documents" / watched_file.name
+    assert entry.target == str(expected_target)
+    assert entry.conflict is False
+
+
+def test_render_move_plan_json(tmp_path):
+    watched_file = tmp_path / "sample.txt"
+    events = [FileSystemEvent(path=watched_file, event_type=EventType.DELETED)]
+
+    # Deleted file should be ignored resulting in empty plan.
+    entries = generate_move_plan(events, destination_root=tmp_path)
+    assert entries == []
+
+    json_output = render_move_plan_json(entries)
+    assert json_output == "[]"

--- a/auto_organizer/tests/test_watcher_event_queue.py
+++ b/auto_organizer/tests/test_watcher_event_queue.py
@@ -1,0 +1,55 @@
+"""Tests for watcher event queue merging and flushing."""
+from __future__ import annotations
+
+import time
+from pathlib import Path
+
+from auto_organizer.watcher.event_queue import EventQueue
+from auto_organizer.watcher.types import EventType, FileSystemEvent
+
+
+def make_event(path: Path, event_type: EventType) -> FileSystemEvent:
+    return FileSystemEvent(path=path, event_type=event_type)
+
+
+def test_event_queue_debounce_merges(tmp_path):
+    emitted: list[list[FileSystemEvent]] = []
+    queue = EventQueue(emitted.append, debounce_interval=0.5, flush_interval=10)
+
+    path = tmp_path / "file.txt"
+    event1 = make_event(path, EventType.CREATED)
+    event2 = make_event(path, EventType.MODIFIED)
+
+    queue.add(event1)
+    queue.add(event2)
+    queue.flush_due(force=True)
+
+    assert len(emitted) == 1
+    assert emitted[0][0].event_type is EventType.CREATED
+
+
+def test_event_queue_prefers_delete(tmp_path):
+    emitted: list[list[FileSystemEvent]] = []
+    queue = EventQueue(emitted.append, debounce_interval=0.5, flush_interval=10)
+
+    path = tmp_path / "file.txt"
+    queue.add(make_event(path, EventType.CREATED))
+    queue.add(make_event(path, EventType.DELETED))
+    queue.flush_due(force=True)
+
+    assert emitted[0][0].event_type is EventType.DELETED
+
+
+def test_event_queue_flushes_after_interval(tmp_path):
+    emitted: list[list[FileSystemEvent]] = []
+    queue = EventQueue(emitted.append, debounce_interval=0.05, flush_interval=0.1)
+
+    path = tmp_path / "file.txt"
+    queue.add(make_event(path, EventType.CREATED))
+    queue.flush_due()
+    assert emitted == []
+
+    time.sleep(0.12)
+    queue.flush_due()
+    assert len(emitted) == 1
+    assert emitted[0][0].path == path

--- a/auto_organizer/watcher/__init__.py
+++ b/auto_organizer/watcher/__init__.py
@@ -1,0 +1,12 @@
+"""Watcher subsystem for AutoOrganizer."""
+from .event_queue import EventQueue
+from .dryrun import generate_move_plan, render_move_plan_json
+from .types import EventType, FileSystemEvent
+
+__all__ = [
+    "EventQueue",
+    "EventType",
+    "FileSystemEvent",
+    "generate_move_plan",
+    "render_move_plan_json",
+]

--- a/auto_organizer/watcher/dryrun.py
+++ b/auto_organizer/watcher/dryrun.py
@@ -1,0 +1,102 @@
+"""Dry-run utilities for the watcher subsystem."""
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Iterable, Mapping, Sequence
+
+from ..classifier import ClassificationEngine
+from ..models import FileCandidate
+from ..planner import Planner
+from .types import EventType, FileSystemEvent
+
+
+@dataclass(slots=True)
+class MovePlanEntry:
+    """Serializable entry for the watcher dry-run output."""
+
+    path: str
+    predicted_category: str
+    target: str
+    confidence: float
+    conflict: bool
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "path": self.path,
+            "predicted_category": self.predicted_category,
+            "target": self.target,
+            "confidence": self.confidence,
+            "conflict": self.conflict,
+        }
+
+
+def generate_move_plan(
+    events: Sequence[FileSystemEvent],
+    *,
+    destination_root: str | Path,
+    classifier: ClassificationEngine | None = None,
+    category_mapping: Mapping[str, str] | None = None,
+) -> list[MovePlanEntry]:
+    """Produce a dry-run move plan for *events*.
+
+    Only creation, modification and move events are considered. Missing files are
+    ignored. The function returns a list of :class:`MovePlanEntry` objects.
+    """
+
+    classifier = classifier or ClassificationEngine()
+    planner = Planner(
+        destination_root=destination_root,
+        category_mapping=category_mapping,
+        classifier=classifier,
+    )
+
+    candidates: list[FileCandidate] = []
+    classifications: list[tuple[str, float]] = []
+
+    for event in events:
+        if event.event_type not in {EventType.CREATED, EventType.MODIFIED, EventType.MOVED}:
+            continue
+        path = event.dest_path or event.path
+        if not path.exists() or path.is_dir():
+            continue
+        stat = path.stat()
+        candidate = FileCandidate(
+            path=path,
+            size=stat.st_size,
+            modified_at=datetime.fromtimestamp(stat.st_mtime),
+            is_symlink=path.is_symlink(),
+        )
+        result = classifier.classify(candidate)
+        candidates.append(candidate)
+        classifications.append((result.category, result.confidence))
+
+    if not candidates:
+        return []
+
+    plan_result = planner.plan(candidates)
+    entries: list[MovePlanEntry] = []
+
+    for (category, confidence), plan_item in zip(classifications, plan_result.items):
+        entries.append(
+            MovePlanEntry(
+                path=str(plan_item.source),
+                predicted_category=category,
+                target=str(plan_item.destination),
+                confidence=confidence,
+                conflict=plan_item.conflict,
+            )
+        )
+
+    return entries
+
+
+def render_move_plan_json(entries: Iterable[MovePlanEntry], *, indent: int = 2) -> str:
+    """Serialize :class:`MovePlanEntry` objects into JSON."""
+
+    return json.dumps([entry.to_dict() for entry in entries], indent=indent)
+
+
+__all__ = ["MovePlanEntry", "generate_move_plan", "render_move_plan_json"]

--- a/auto_organizer/watcher/event_queue.py
+++ b/auto_organizer/watcher/event_queue.py
@@ -1,0 +1,92 @@
+"""Event queue with debouncing and merge semantics for watcher events."""
+from __future__ import annotations
+
+import threading
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Callable, Dict
+
+from .types import EventType, FileSystemEvent
+
+
+@dataclass(slots=True)
+class _QueuedEvent:
+    event: FileSystemEvent
+    last_seen: float
+
+
+class EventQueue:
+    """Coalesce filesystem events before emitting them downstream."""
+
+    def __init__(
+        self,
+        emit: Callable[[list[FileSystemEvent]], None],
+        *,
+        debounce_interval: float = 0.2,
+        flush_interval: float = 1.0,
+    ) -> None:
+        self._emit = emit
+        self.debounce_interval = debounce_interval
+        self.flush_interval = flush_interval
+        self._pending: Dict[Path, _QueuedEvent] = {}
+        self._lock = threading.Lock()
+
+    def add(self, event: FileSystemEvent) -> None:
+        """Add *event* to the queue, merging it if necessary."""
+
+        now = time.monotonic()
+        key = event.path
+
+        with self._lock:
+            queued = self._pending.get(key)
+            if queued and (now - queued.last_seen) <= self.debounce_interval:
+                queued.event = self._merge_events(queued.event, event)
+                queued.last_seen = now
+            else:
+                self._pending[key] = _QueuedEvent(event=event, last_seen=now)
+
+    def flush_due(self, *, force: bool = False) -> None:
+        """Flush ready events to the downstream callback."""
+
+        now = time.monotonic()
+        ready: list[FileSystemEvent] = []
+
+        with self._lock:
+            for key, queued in list(self._pending.items()):
+                if force or (now - queued.last_seen) >= self.flush_interval:
+                    ready.append(queued.event)
+                    del self._pending[key]
+
+        if ready:
+            self._emit(ready)
+
+    def clear(self) -> None:
+        """Clear internal buffers without emitting events."""
+
+        with self._lock:
+            self._pending.clear()
+
+    @staticmethod
+    def _merge_events(existing: FileSystemEvent, new: FileSystemEvent) -> FileSystemEvent:
+        """Merge two events targeting the same path."""
+
+        if new.event_type is EventType.DELETED:
+            merged_type = EventType.DELETED
+        elif new.event_type is EventType.MOVED:
+            merged_type = EventType.MOVED
+        elif existing.event_type is EventType.CREATED and new.event_type is EventType.MODIFIED:
+            merged_type = EventType.CREATED
+        else:
+            merged_type = new.event_type
+
+        existing.event_type = merged_type
+        existing.timestamp = new.timestamp
+        existing.is_directory = new.is_directory
+        if new.dest_path is not None:
+            existing.dest_path = new.dest_path
+        existing.metadata.update(new.metadata)
+        return existing
+
+
+__all__ = ["EventQueue"]

--- a/auto_organizer/watcher/types.py
+++ b/auto_organizer/watcher/types.py
@@ -1,0 +1,32 @@
+"""Shared type definitions for the watcher subsystem."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum, auto
+from pathlib import Path
+from typing import Any
+import time
+
+
+class EventType(Enum):
+    """Normalized filesystem event types that the watcher understands."""
+
+    CREATED = auto()
+    MODIFIED = auto()
+    DELETED = auto()
+    MOVED = auto()
+
+
+@dataclass(slots=True)
+class FileSystemEvent:
+    """Container describing a single filesystem change event."""
+
+    path: Path
+    event_type: EventType
+    timestamp: float = field(default_factory=lambda: time.time())
+    is_directory: bool = False
+    dest_path: Path | None = None
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+
+__all__ = ["EventType", "FileSystemEvent"]


### PR DESCRIPTION
## Summary
- add a watcher package with reusable event types, queue coalescing, and dry-run helpers
- update the realtime watcher with polling fallback and the shared event queue
- document the watcher module and cover the new logic with unit tests

## Testing
- PYTHONPATH=. pytest auto_organizer/tests/test_watcher_event_queue.py auto_organizer/tests/test_watcher_dryrun.py auto_organizer/tests/test_realtime_watcher.py

------
https://chatgpt.com/codex/tasks/task_e_68e557afbe5c832ea9da7ed4eb6ec07f