### PR TITLE
Add rules preview/apply commands and report rendering

### DIFF
--- a/auto_organizer/__main__.py
+++ b/auto_organizer/__main__.py
@@ -1,0 +1,8 @@
+"""Module entry point for ``python -m auto_organizer``."""
+from __future__ import annotations
+
+from .cli import main
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/auto_organizer/reporting.py
+++ b/auto_organizer/reporting.py
@@ -1,0 +1,62 @@
+"""Rendering helpers for AutoOrganizer reports."""
+from __future__ import annotations
+
+import json
+from typing import Mapping
+
+
+def render_report(raw: Mapping[str, object], fmt: str) -> str:
+    """Render a normalized report payload according to *fmt*.
+
+    ``fmt`` accepts ``"text"``, ``"markdown"`` or ``"json"``.
+    """
+
+    fmt = fmt.lower()
+    if fmt == "json":
+        payload = dict(raw)
+        payload.setdefault("version", "1.0")
+        return json.dumps(payload, indent=2, ensure_ascii=False)
+
+    totals = raw.get("totals", {}) if isinstance(raw, Mapping) else {}
+    classification = raw.get("classification", {}) if isinstance(raw, Mapping) else {}
+
+    if fmt == "markdown":
+        lines = [
+            "# AutoOrganizer Report",
+            "",
+            "## Summary",
+            f"- Processed files: {totals.get('processed', 0)}",
+            f"- Moved files: {totals.get('moved', 0)}",
+            f"- Skipped files: {totals.get('skipped', 0)}",
+            f"- Errors: {totals.get('errors', 0)}",
+            "",
+            "## Classification",
+        ]
+        if classification:
+            lines.append("| Category | Count |")
+            lines.append("| --- | --- |")
+            for key, value in sorted(classification.items()):
+                lines.append(f"| {key} | {value} |")
+        else:
+            lines.append("(no classification data)")
+        return "\n".join(lines)
+
+    lines = [
+        "AutoOrganizer Report",
+        "====================",
+        f"Processed: {totals.get('processed', 0)}",
+        f"Moved: {totals.get('moved', 0)}",
+        f"Skipped: {totals.get('skipped', 0)}",
+        f"Errors: {totals.get('errors', 0)}",
+        "",
+        "Classification:",
+    ]
+    if classification:
+        for key, value in sorted(classification.items()):
+            lines.append(f"  - {key}: {value}")
+    else:
+        lines.append("  (no data)")
+    return "\n".join(lines)
+
+
+__all__ = ["render_report"]

--- a/auto_organizer/utils/__init__.py
+++ b/auto_organizer/utils/__init__.py
@@ -1,0 +1,4 @@
+"""Utility helpers for AutoOrganizer."""
+from __future__ import annotations
+
+__all__ = []

--- a/auto_organizer/utils/fs.py
+++ b/auto_organizer/utils/fs.py
@@ -1,0 +1,32 @@
+"""Filesystem helpers used by AutoOrganizer."""
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def ensure_directory(path: Path) -> Path:
+    """Ensure that *path* exists as a directory and return it."""
+
+    path.mkdir(parents=True, exist_ok=True)
+    return path
+
+
+def unique_path(base: Path, *, reserved: set[Path] | None = None) -> Path:
+    """Return a unique path derived from *base*.
+
+    The function checks both the filesystem and the ``reserved`` set to avoid
+    collisions. The provided ``reserved`` set will be updated with the selected
+    path when supplied.
+    """
+
+    reserved_paths: set[Path] = reserved if reserved is not None else set()
+    candidate = base
+    counter = 1
+    while candidate in reserved_paths or candidate.exists():
+        candidate = candidate.with_name(f"{base.stem}_{counter}{base.suffix}")
+        counter += 1
+    reserved_paths.add(candidate)
+    return candidate
+
+
+__all__ = ["ensure_directory", "unique_path"]


### PR DESCRIPTION
## Summary
- add CLI subcommands for `rules preview` and `rules apply`, including logging and argument wiring
- implement classification planning/move logic with preview output, rollback generation, and filesystem helpers
- add report rendering utility with format selection plus a package `__main__` entry point

## Testing
- python -m auto_organizer --help
- python -m auto_organizer rules --help
- python -m auto_organizer rules preview --help
- python -m auto_organizer rules apply --help
- python -m auto_organizer rules preview --config ~/AutoOrgSandbox/rules.json --source ~/AutoOrgSandbox/input --target ~/AutoOrgSandbox/output --limit 50 --output ~/AutoOrgSandbox/preview.md
- python -m auto_organizer rules apply --config ~/AutoOrgSandbox/rules.json --source ~/AutoOrgSandbox/input --target ~/AutoOrgSandbox/output --rollback ~/AutoOrgSandbox/rollback.json
- python -m auto_organizer report summary --format markdown --output ~/AutoOrgSandbox/report.md || true

------
https://chatgpt.com/codex/tasks/task_e_68e63b52c43c832e9bbda938d61d3b6f